### PR TITLE
fix: iOS Safari styling and resume layout on mobile

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -51,6 +51,10 @@
   display: flex;
 
   color: var(--text-primary);
+  /* iOS Safari 색상 문제 해결: -webkit-text-fill-color 명시 */
+  -webkit-text-fill-color: var(--text-primary);
+  /* Safari 자동 링크 감지로 인한 색상 변경 방지 */
+  -webkit-text-decoration: none;
 }
 
 .introduction {

--- a/src/app/resume/page.module.css
+++ b/src/app/resume/page.module.css
@@ -249,8 +249,8 @@
   }
 
   .infoGrid {
-    grid-template-columns: 1fr;
-    gap: var(--space-6);
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-6) var(--space-8);
     margin-bottom: var(--space-12);
     padding-bottom: var(--space-10);
   }


### PR DESCRIPTION
## Summary
This PR addresses styling issues on iOS Safari and improves the resume page layout on mobile devices.

## Key Changes
- **iOS Safari text color fix**: Added `-webkit-text-fill-color` property to explicitly set text color, resolving color rendering issues in iOS Safari
- **Link decoration prevention**: Added `-webkit-text-decoration: none` to prevent Safari's automatic link detection from overriding text styling
- **Resume info grid layout**: Changed mobile layout from single column (`1fr`) to two-column layout (`repeat(2, 1fr)`) with adjusted gap spacing (`var(--space-6) var(--space-8)`) for better space utilization

## Implementation Details
- The webkit-specific properties are vendor prefixes necessary for proper rendering on Safari browsers
- The resume grid layout now uses a more compact two-column arrangement on mobile, improving information density while maintaining readability