### PR TITLE
docs: 에이전트 프리체크와 작업 단위 워크플로 강제

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,48 @@
 **Commit:** unknown
 **Branch:** main
 
+## MUST PRECHECK (NON-OPTIONAL)
+
+Before running any implementation command, every agent **must** do all of the following:
+
+1. Open and read these files directly (do not rely on links only):
+   - `.agent/rules/meta-prompt.md`
+   - `.agent/rules/meta-prompt-engineering.md`
+   - `.agent/rules/meta-prompt-personal-preferences.md`
+   - `.agent/rules/meta-prompt-knowledge-sync.md`
+   - `.agent/rules/product-rules.md`
+   - `.agent/rules/meta-prompt-toss-inspired.md`
+2. In the first progress update, explicitly report:
+   - opened file list
+   - top 3 rules applied for this task
+3. If precheck is not complete, stop immediately and do not implement.
+
+## WORK UNIT FLOW (MANDATORY)
+
+Each work unit must follow this flow in order:
+
+1. Create a branch with prefix `codex/`.
+2. Link the work to a GitHub Issue.
+3. Complete implementation and verification.
+4. Open a PR that includes the issue link.
+5. Only after PR creation, move to the next work unit.
+
+Required PR/Issue linkage format:
+
+- PR body must include `Refs #<issue-number>` at minimum.
+- If the work fully completes the issue, use `Closes #<issue-number>`.
+
+## BLOCKED POLICY (MANDATORY)
+
+If a work unit is blocked by another issue/PR:
+
+1. Mark the current issue/PR as blocked immediately.
+2. Add the exact blocking link(s):
+   - blocked by issue: `Blocked by #<issue-number>`
+   - blocked by PR: `Blocked by <pr-url>`
+3. Prioritize unblocking work so the dependency can be merged first.
+4. Do not continue dependent implementation until the blocker is resolved.
+
 ## OVERVIEW
 
 Modern tech blog platform with interactive 3D animations built on Next.js 14+ App Router, emphasizing memorable user experiences through particle-based animations and newspaper-inspired design.


### PR DESCRIPTION
## 변경 내용
- `AGENTS.md`에 에이전트 필수 프리체크 규칙 추가
- 작업 단위 브랜치/이슈/PR 순서 강제 규칙 추가
- Blocked 이슈/PR 링크 명시 및 선행 병합 우선 정책 추가

## 의도
- 링크 문서 미열람 누락을 방지
- 모든 에이전트가 동일한 작업 프로토콜을 따르도록 강제
- 의존 이슈/PR이 있을 때 병목을 빠르게 해소

## 검증
- 문서 변경 diff 확인 완료
- 규칙 문구가 실행 절차로 바로 사용 가능한지 검토 완료

Refs #25
