### PR TITLE
fix: 타입 안정성과 라우트 상태 경계 보강

### DIFF
--- a/src/app/blog/[slug]/error.tsx
+++ b/src/app/blog/[slug]/error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { EmptyState } from '@/components/ui';
+import { Header } from '@/components/layout';
+
+interface BlogPostErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function BlogPostError({ error, reset }: BlogPostErrorProps) {
+  return (
+    <>
+      <Header />
+      <main>
+        <EmptyState
+          icon="⚠️"
+          title="글을 불러오지 못했습니다"
+          description={error.message || '잠시 후 다시 시도해 주세요.'}
+          action={{ label: '다시 시도', onClick: reset }}
+        />
+      </main>
+    </>
+  );
+}

--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -1,0 +1,17 @@
+import { EmptyState } from '@/components/ui';
+import { Header } from '@/components/layout';
+
+export default function BlogPostLoading() {
+  return (
+    <>
+      <Header />
+      <main>
+        <EmptyState
+          icon="✍️"
+          title="글을 불러오는 중입니다"
+          description="콘텐츠를 준비하고 있습니다."
+        />
+      </main>
+    </>
+  );
+}

--- a/src/app/blog/error.tsx
+++ b/src/app/blog/error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { EmptyState } from '@/components/ui';
+import { Header } from '@/components/layout';
+
+interface BlogErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function BlogError({ error, reset }: BlogErrorProps) {
+  return (
+    <>
+      <Header />
+      <main>
+        <EmptyState
+          icon="⚠️"
+          title="글 목록을 불러오지 못했습니다"
+          description={error.message || '네트워크 상태를 확인하고 다시 시도해 주세요.'}
+          action={{ label: '다시 시도', onClick: reset }}
+        />
+      </main>
+    </>
+  );
+}

--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -1,0 +1,17 @@
+import { EmptyState } from '@/components/ui';
+import { Header } from '@/components/layout';
+
+export default function BlogLoading() {
+  return (
+    <>
+      <Header />
+      <main>
+        <EmptyState
+          icon="📰"
+          title="글 목록을 불러오는 중입니다"
+          description="최신 글을 준비하고 있습니다."
+        />
+      </main>
+    </>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { EmptyState } from '@/components/ui';
+
+interface RootErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RootError({ error, reset }: RootErrorProps) {
+  return (
+    <main>
+      <EmptyState
+        icon="⚠️"
+        title="페이지를 불러오지 못했습니다"
+        description={error.message || '잠시 후 다시 시도해 주세요.'}
+        action={{ label: '다시 시도', onClick: reset }}
+      />
+    </main>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,13 @@
+import { EmptyState } from '@/components/ui';
+
+export default function RootLoading() {
+  return (
+    <main>
+      <EmptyState
+        icon="⏳"
+        title="페이지를 불러오는 중입니다"
+        description="잠시만 기다려 주세요."
+      />
+    </main>
+  );
+}

--- a/src/app/resume/error.tsx
+++ b/src/app/resume/error.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { EmptyState } from '@/components/ui';
+import { Header } from '@/components/layout';
+
+interface ResumeErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ResumeError({ error, reset }: ResumeErrorProps) {
+  return (
+    <>
+      <Header />
+      <main>
+        <EmptyState
+          icon="⚠️"
+          title="이력서를 불러오지 못했습니다"
+          description={error.message || '잠시 후 다시 시도해 주세요.'}
+          action={{ label: '다시 시도', onClick: reset }}
+        />
+      </main>
+    </>
+  );
+}

--- a/src/app/resume/loading.tsx
+++ b/src/app/resume/loading.tsx
@@ -1,0 +1,17 @@
+import { EmptyState } from '@/components/ui';
+import { Header } from '@/components/layout';
+
+export default function ResumeLoading() {
+  return (
+    <>
+      <Header />
+      <main>
+        <EmptyState
+          icon="📄"
+          title="이력서를 불러오는 중입니다"
+          description="콘텐츠를 준비하고 있습니다."
+        />
+      </main>
+    </>
+  );
+}

--- a/src/components/providers/KBarProvider.tsx
+++ b/src/components/providers/KBarProvider.tsx
@@ -4,10 +4,11 @@ import { KBarProvider as KBarProviderLib } from 'kbar';
 import { CommandPalette } from '@/components/common/CommandPalette';
 import { getSearchActions } from '@/lib/search';
 import { useMemo } from 'react';
+import { FeedData } from '@/types';
 
 interface KBarProviderProps {
   children: React.ReactNode;
-  posts?: any[];
+  posts?: FeedData[];
 }
 
 export default function KBarProvider({ children, posts = [] }: KBarProviderProps) {

--- a/src/components/seo/JsonLd.test.tsx
+++ b/src/components/seo/JsonLd.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import JsonLd from './JsonLd';
+
+describe('JsonLd', () => {
+  it('renders schema payload as JSON script content', () => {
+    const data = {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'eunu.log',
+    };
+
+    const { container } = render(<JsonLd data={data} />);
+    const script = container.querySelector('script[type="application/ld+json"]');
+
+    expect(script).not.toBeNull();
+    expect(script?.innerHTML).toContain('"@type":"WebSite"');
+    expect(script?.innerHTML).toContain('"name":"eunu.log"');
+  });
+});

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -1,4 +1,12 @@
-export default function JsonLd({ data }: { data: Record<string, any> }) {
+type JsonLdPrimitive = string | number | boolean | null;
+type JsonLdValue = JsonLdPrimitive | JsonLdObject | JsonLdValue[];
+type JsonLdObject = { [key: string]: JsonLdValue };
+
+interface JsonLdProps {
+  data: JsonLdObject;
+}
+
+export default function JsonLd({ data }: JsonLdProps) {
   return (
     <script
       type="application/ld+json"

--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getSearchActions } from './search';
+import { FeedData } from '@/types';
+
+describe('getSearchActions', () => {
+  it('creates kbar actions from feed posts', () => {
+    const posts: FeedData[] = [
+      {
+        title: '테스트 포스트',
+        slug: 'test-post',
+        description: '검색 액션 생성을 테스트합니다.',
+        date: '2026-02-12',
+        category: 'Frontend',
+        tags: ['react', 'kbar'],
+      },
+    ];
+
+    const actions = getSearchActions(posts);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].id).toBe('test-post');
+    expect(actions[0].name).toBe('테스트 포스트');
+    expect(actions[0].section).toBe('블로그 포스트');
+    expect(actions[0].subtitle).toBe('검색 액션 생성을 테스트합니다.');
+    expect(actions[0].keywords).toContain('Frontend');
+    expect(actions[0].keywords).toContain('react');
+  });
+});

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,19 +1,20 @@
 import { Action } from 'kbar';
+import { FeedData } from '@/types';
 
 /**
  * 전역 검색을 위한 액션 초기 데이터 생성 함수
  * 블로그 포스트를 검색할 수 있게 액션 객체 배열을 반환합니다.
  */
-export const getSearchActions = (posts: any[]): Action[] => {
-    const postActions = posts.map((post) => ({
-        id: post.slug,
-        name: post.title,
-        shortcut: [],
-        keywords: `${post.title} ${post.category} ${post.tags?.join(' ')} ${post.description}`,
-        section: '블로그 포스트',
-        perform: () => (window.location.href = `/blog/${post.slug}`),
-        subtitle: post.description,
-    }));
+export const getSearchActions = (posts: FeedData[]): Action[] => {
+  const postActions = posts.map((post) => ({
+    id: post.slug,
+    name: post.title,
+    shortcut: [],
+    keywords: `${post.title} ${post.category} ${post.tags?.join(' ')} ${post.description}`,
+    section: '블로그 포스트',
+    perform: () => (window.location.href = `/blog/${post.slug}`),
+    subtitle: post.description,
+  }));
 
-    return postActions;
+  return postActions;
 };


### PR DESCRIPTION
## 변경 내용
- `any` 타입 제거
  - `src/components/seo/JsonLd.tsx`
  - `src/lib/search.ts`
  - `src/components/providers/KBarProvider.tsx`
- route-level 상태 경계 추가
  - `src/app/loading.tsx`, `src/app/error.tsx`
  - `src/app/blog/loading.tsx`, `src/app/blog/error.tsx`
  - `src/app/blog/[slug]/loading.tsx`, `src/app/blog/[slug]/error.tsx`
  - `src/app/resume/loading.tsx`, `src/app/resume/error.tsx`
- 회귀 방지 테스트 추가
  - `src/lib/search.test.ts`
  - `src/components/seo/JsonLd.test.tsx`

## 검증
- `npm test -- --run` 통과
- `npm run build` 통과

Closes #20
