### PR TITLE
chore: .husky/.vscode 추적 해제 및 ignore 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local tooling / editor
+.vscode/
+.husky/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npx lint-staged

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "files.exclude": {
-    "**\"": true
-  }
-}


### PR DESCRIPTION
## 변경 내용
- `.gitignore`에 `.husky/`, `.vscode/` 추가
- `master`에서 추적 중이던 `.husky/pre-commit`, `.vscode/settings.json` 제거

## 의도
- 로컬 개발 환경 파일이 원격 `master`에 섞이지 않도록 정리

## 검증
- `git status` clean
- 해당 경로가 ignore 규칙으로 재추적되지 않음
