### PR TITLE
feat(blog): 모바일 TOC 시트와 활성 섹션 동기화

### DIFF
--- a/src/features/blog/ui/components/MobileTocSheet.test.tsx
+++ b/src/features/blog/ui/components/MobileTocSheet.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MobileTocSheet from './MobileTocSheet';
+
+const mockTrackEvent = vi.fn();
+
+vi.mock('@/shared/analytics/lib/analytics', () => ({
+  AnalyticsEvents: {
+    tocOpened: 'toc_opened',
+  },
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
+describe('MobileTocSheet', () => {
+  it('opens dialog and navigates to heading', () => {
+    const onNavigate = vi.fn();
+
+    render(
+      <MobileTocSheet
+        items={[{ id: 'sec-1', text: '섹션 1', level: 2 }]}
+        activeId="sec-1"
+        postSlug="sample"
+        onNavigate={onNavigate}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '목차 열기' }));
+
+    expect(screen.getByRole('dialog', { name: '목차' })).toBeInTheDocument();
+    expect(mockTrackEvent).toHaveBeenCalledWith('toc_opened', {
+      surface: 'mobile_toc_sheet',
+      active_heading: 'sec-1',
+      post_slug: 'sample',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '섹션 1' }));
+    expect(onNavigate).toHaveBeenCalledWith('sec-1');
+  });
+});

--- a/src/features/blog/ui/components/MobileTocSheet.tsx
+++ b/src/features/blog/ui/components/MobileTocSheet.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+
+interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface MobileTocSheetProps {
+  items: TocItem[];
+  activeId: string;
+  postSlug?: string;
+  onNavigate: (id: string) => void;
+}
+
+export default function MobileTocSheet({
+  items,
+  activeId,
+  postSlug,
+  onNavigate,
+}: MobileTocSheetProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const activeItemText = useMemo(
+    () => items.find((item) => item.id === activeId)?.text,
+    [activeId, items]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setIsOpen(true);
+          trackEvent(AnalyticsEvents.tocOpened, {
+            surface: 'mobile_toc_sheet',
+            active_heading: activeId || 'none',
+            post_slug: postSlug,
+          });
+        }}
+        className="xl:hidden fixed bottom-24 right-4 z-[var(--z-overlay)] flex max-w-xs items-center gap-2 rounded-full border border-[var(--color-grey-200)] bg-[var(--color-bg-primary)] px-4 py-2 text-sm font-semibold text-[var(--color-grey-800)] shadow-[var(--shadow-lg)]"
+        aria-label="목차 열기"
+      >
+        <span className="inline-block h-2 w-2 rounded-full bg-[var(--color-toss-blue)]" />
+        <span className="truncate">{activeItemText ?? '목차 열기'}</span>
+      </button>
+
+      {isOpen && (
+        <div
+          className="xl:hidden fixed inset-0 z-[var(--z-modal)]"
+          aria-hidden={!isOpen}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 bg-[rgba(0,0,0,0.45)]"
+            aria-label="목차 닫기"
+            onClick={() => setIsOpen(false)}
+          />
+
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mobile-toc-title"
+            className="absolute inset-x-0 bottom-0 flex h-3/4 flex-col rounded-t-2xl bg-[var(--color-bg-primary)] p-4 shadow-[var(--shadow-xl)]"
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <h2
+                id="mobile-toc-title"
+                className="text-sm font-semibold text-[var(--color-grey-900)]"
+              >
+                목차
+              </h2>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="rounded-md px-2 py-1 text-sm text-[var(--color-grey-600)] hover:bg-[var(--color-grey-100)]"
+                aria-label="목차 닫기"
+              >
+                닫기
+              </button>
+            </div>
+
+            <p className="mb-3 text-xs text-[var(--color-grey-500)]">
+              현재 섹션: {activeItemText ?? '없음'}
+            </p>
+
+            <div className="flex-1 overflow-y-auto">
+              <ul className="flex flex-col gap-1">
+                {items.map((item) => (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onNavigate(item.id);
+                        setIsOpen(false);
+                      }}
+                      className={clsx(
+                        'w-full rounded-lg px-3 py-2 text-left text-sm transition-colors',
+                        item.level > 2 && 'pl-6',
+                        activeId === item.id
+                          ? 'bg-[var(--color-toss-blue)]/10 text-[var(--color-toss-blue)] font-semibold'
+                          : 'text-[var(--color-grey-700)] hover:bg-[var(--color-grey-100)]'
+                      )}
+                    >
+                      {item.text}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        </div>
+      )}
+    </>
+  );
+}
+
+export type { MobileTocSheetProps };

--- a/src/features/blog/ui/components/TableOfContents/TableOfContents.tsx
+++ b/src/features/blog/ui/components/TableOfContents/TableOfContents.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { clsx } from 'clsx';
+import MobileTocSheet from '../MobileTocSheet';
 
 interface TocItem {
   id: string;
@@ -11,78 +12,117 @@ interface TocItem {
 
 interface TableOfContentsProps {
   items: TocItem[];
+  postSlug?: string;
 }
 
-export default function TableOfContents({ items }: TableOfContentsProps) {
-  const [activeId, setActiveId] = useState<string>('');
+function scrollToHeading(id: string) {
+  const element = document.getElementById(id);
+
+  if (!element) {
+    return;
+  }
+
+  const yOffset = -100;
+  const yPosition =
+    element.getBoundingClientRect().top + window.pageYOffset + yOffset;
+
+  window.scrollTo({ top: yPosition, behavior: 'smooth' });
+  window.history.replaceState(null, '', `#${id}`);
+}
+
+export default function TableOfContents({
+  items,
+  postSlug,
+}: TableOfContentsProps) {
+  const [activeId, setActiveId] = useState<string>(items[0]?.id ?? '');
+
+  const headingIds = useMemo(() => items.map((item) => item.id), [items]);
 
   useEffect(() => {
+    if (headingIds.length === 0) {
+      return;
+    }
+
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
-          }
-        });
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort(
+            (leftEntry, rightEntry) =>
+              leftEntry.boundingClientRect.top -
+              rightEntry.boundingClientRect.top
+          );
+
+        if (visibleEntries.length > 0) {
+          setActiveId(visibleEntries[0].target.id);
+        }
       },
       {
-        rootMargin: '-80px 0px -80% 0px',
+        rootMargin: '-88px 0px -65% 0px',
+        threshold: [0, 0.4, 1],
       }
     );
 
-    items.forEach((item) => {
-      const element = document.getElementById(item.id);
-      if (element) observer.observe(element);
+    headingIds.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) {
+        observer.observe(element);
+      }
     });
 
     return () => observer.disconnect();
-  }, [items]);
+  }, [headingIds]);
 
-  const handleClick = (id: string) => {
-    const element = document.getElementById(id);
-    if (element) {
-      const yOffset = -100;
-      const y =
-        element.getBoundingClientRect().top + window.pageYOffset + yOffset;
-      window.scrollTo({ top: y, behavior: 'smooth' });
-
-      // Update URL hash without jumping and without adding to history
-      window.history.replaceState(null, '', `#${id}`);
-    }
+  const handleNavigate = (id: string) => {
+    setActiveId(id);
+    scrollToHeading(id);
   };
 
-  if (items.length === 0) return null;
+  if (items.length === 0) {
+    return null;
+  }
 
   return (
-    <nav
-      className="hidden xl:block fixed right-8 top-1/2 -translate-y-1/2 w-64 max-h-[80vh]"
-      aria-label="목차"
-    >
-      <div className="p-4 bg-[var(--color-grey-50)] rounded-[var(--radius-md)] max-h-[80vh] overflow-y-auto">
-        <h2 className="text-sm font-semibold text-[var(--color-grey-900)] mb-4 sticky top-0 bg-[var(--color-grey-50)] pb-2">
-          목차
-        </h2>
-        <ul className="flex flex-col gap-1">
-          {items.map((item) => (
-            <li key={item.id}>
-              <button
-                onClick={() => handleClick(item.id)}
-                className={clsx(
-                  'block w-full text-left text-sm py-1.5 px-3 rounded-[6px]',
-                  'transition-colors duration-[var(--duration-150)]',
-                  item.level > 2 && 'pl-6',
-                  activeId === item.id
-                    ? 'bg-[var(--color-toss-blue)]/10 text-[var(--color-toss-blue)] font-medium'
-                    : 'text-[var(--color-grey-600)] hover:text-[var(--color-grey-900)] hover:bg-[var(--color-grey-100)]'
-                )}
-              >
-                {item.text}
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </nav>
+    <>
+      <nav
+        className="hidden xl:block fixed right-8 top-1/2 -translate-y-1/2 w-64 max-h-[80vh]"
+        aria-label="목차"
+      >
+        <div className="p-4 bg-[var(--color-grey-50)] rounded-[var(--radius-md)] max-h-[80vh] overflow-y-auto">
+          <h2 className="text-sm font-semibold text-[var(--color-grey-900)] mb-4 sticky top-0 bg-[var(--color-grey-50)] pb-2">
+            목차
+          </h2>
+          <ul className="flex flex-col gap-1">
+            {items.map((item) => (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  onClick={() => handleNavigate(item.id)}
+                  className={clsx(
+                    'block w-full text-left text-sm py-1.5 px-3 rounded-[6px]',
+                    'transition-colors duration-[var(--duration-150)]',
+                    item.level > 2 && 'pl-6',
+                    activeId === item.id
+                      ? 'bg-[var(--color-toss-blue)]/10 text-[var(--color-toss-blue)] font-medium'
+                      : 'text-[var(--color-grey-600)] hover:text-[var(--color-grey-900)] hover:bg-[var(--color-grey-100)]'
+                  )}
+                  aria-current={activeId === item.id ? 'location' : undefined}
+                >
+                  {item.text}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </nav>
+
+      <MobileTocSheet
+        items={items}
+        activeId={activeId}
+        postSlug={postSlug}
+        onNavigate={handleNavigate}
+      />
+    </>
   );
 }
 

--- a/src/features/blog/ui/components/index.ts
+++ b/src/features/blog/ui/components/index.ts
@@ -10,6 +10,7 @@ export type { CategoryFilterProps, Category } from './CategoryFilter';
 
 export { TableOfContents } from './TableOfContents';
 export type { TableOfContentsProps, TocItem } from './TableOfContents';
+export { default as MobileTocSheet } from './MobileTocSheet';
 
 export { ReadingProgress } from './ReadingProgress';
 export { ImageGrid } from './ImageGrid';

--- a/src/features/blog/ui/pages/BlogPostPage.tsx
+++ b/src/features/blog/ui/pages/BlogPostPage.tsx
@@ -1,7 +1,14 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { getFeedData, getAllFeedSlugs, getSeriesPosts } from '@/features/blog/services/post-repository';
-import { getMdxSource, parseHeadingsFromMdx } from '@/features/blog/services/markdown-parser';
+import {
+  getFeedData,
+  getAllFeedSlugs,
+  getSeriesPosts,
+} from '@/features/blog/services/post-repository';
+import {
+  getMdxSource,
+  parseHeadingsFromMdx,
+} from '@/features/blog/services/markdown-parser';
 import { Header, Container } from '@/shared/layout';
 import {
   ReadingProgress,
@@ -168,7 +175,7 @@ export default async function BlogPostPage({
         }}
       />
 
-      <TableOfContents items={tocItems} />
+      <TableOfContents items={tocItems} postSlug={post.slug} />
     </>
   );
 }

--- a/tests/e2e/blog/mobile-toc.spec.ts
+++ b/tests/e2e/blog/mobile-toc.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+const VISUALIZATION_POST_PATH = '/blog/algorithm-visualization';
+
+test.describe('Mobile TOC sheet', () => {
+  test('모바일 목차를 열고 항목 이동 시 해시가 업데이트된다', async ({
+    page,
+  }) => {
+    await page.goto(VISUALIZATION_POST_PATH);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: '목차 열기' }).click();
+
+    const dialog = page.getByRole('dialog', { name: '목차' });
+    await expect(dialog).toBeVisible();
+
+    const headingButton = dialog.locator('ul button').first();
+    await headingButton.click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/#.+/);
+  });
+
+  test('Esc 키로 목차 시트를 닫을 수 있다', async ({ page }) => {
+    await page.goto(VISUALIZATION_POST_PATH);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: '목차 열기' }).click();
+
+    const dialog = page.getByRole('dialog', { name: '목차' });
+    await expect(dialog).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary
- add mobile TOC bottom sheet with keyboard support (`Esc`) and screen-reader labels
- improve TOC active heading detection and jump navigation behavior
- pass current post slug to TOC for analytics payload (`toc_opened`)
- add mobile TOC e2e regression spec

## Test
- `npx vitest run src/features/blog/ui/components/MobileTocSheet.test.tsx`
- `npx playwright test tests/e2e/blog/mobile-toc.spec.ts --project=mobile-chrome`
