### PR TITLE
feat(visualization): 시각화 UX 프레임과 모션 가드레일 적용

### DIFF
--- a/docs/ux/joguman-inspired-ux-guardrails.md
+++ b/docs/ux/joguman-inspired-ux-guardrails.md
@@ -1,0 +1,69 @@
+# Joguman-inspired UX Guardrails
+
+## Scope
+
+- Preserve the current home visual direction.
+- Prioritize blog reading UX, mobile navigation clarity, and motion accessibility.
+- Keep existing token-based design system (`src/styles/tokens.css`) and extend behavior only.
+
+## UX Principles
+
+- Make interaction discoverable before it is delightful.
+- Provide motion controls that respect user/system preferences.
+- Keep long-form reading context visible (current section, quick jumps).
+- Ensure interaction quality on mobile first.
+
+## Motion Policy
+
+- User-selectable mode: `auto | reduced | off`.
+- `auto` follows system `prefers-reduced-motion`.
+- `reduced` keeps state transitions but removes continuous pulse-style motion.
+- `off` disables 3D canvases and serves text guidance instead.
+
+## Visualization Policy
+
+- Every visualization must include:
+  - short controls hint,
+  - current status,
+  - motion mode badge.
+- Default canvas setting: `dpr={[1, 1.5]}`.
+- Track start/pause transitions via analytics events.
+
+## Blog TOC Policy
+
+- Desktop: fixed right TOC with active heading highlight.
+- Mobile: floating TOC trigger + bottom sheet dialog.
+- Support keyboard and screen reader operations:
+  - open/close buttons with labels,
+  - `Esc` closes dialog,
+  - active section announced in sheet.
+
+## Measurement Events
+
+- `motion_mode_changed`
+  - `from_mode`, `to_mode`, `effective_mode`, `surface`
+- `visualization_started`
+  - `component_name`, `motion_mode`, `algorithm?`, `surface`
+- `visualization_paused`
+  - `component_name`, `motion_mode`, `algorithm?`, `surface`
+- `toc_opened`
+  - `surface`, `active_heading`, `post_slug`
+
+## Quality Gates
+
+- Accessibility
+  - reduced-motion behavior is testable and working.
+  - mobile TOC dialog works with tap and keyboard close.
+- Performance (operational target)
+  - LCP <= 2.5s
+  - INP <= 200ms
+  - CLS <= 0.1
+
+## Regression Checks
+
+- Existing mobile navigation smoke tests stay green.
+- Existing theme regression tests stay green.
+- Existing safe-area behavior tests stay green.
+- New e2e tests:
+  - `tests/e2e/accessibility/reduced-motion.spec.ts`
+  - `tests/e2e/blog/mobile-toc.spec.ts`

--- a/src/components/visualization/BinarySearchVisualization.tsx
+++ b/src/components/visualization/BinarySearchVisualization.tsx
@@ -4,6 +4,14 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text } from '@react-three/drei';
 import * as THREE from 'three';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+import {
+  type MotionMode,
+  useEffectiveMotionMode,
+} from '@/shared/motion/model/motion-mode';
+import VisualizationFrame, {
+  VisualizationFallback,
+} from './VisualizationFrame';
 
 interface Element {
   value: number;
@@ -15,15 +23,17 @@ function Box3D({
   position,
   value,
   status,
+  allowPulse,
 }: {
   position: [number, number, number];
   value: number;
   status: string;
+  allowPulse: boolean;
 }) {
   const meshRef = useRef<THREE.Mesh>(null);
 
   useFrame(() => {
-    if (meshRef.current && status === 'mid') {
+    if (meshRef.current && status === 'mid' && allowPulse) {
       const scale = 1 + Math.sin(Date.now() * 0.005) * 0.15;
       meshRef.current.scale.setScalar(scale);
     } else if (meshRef.current) {
@@ -107,7 +117,13 @@ function Box3D({
 }
 
 // Scene component
-function BinarySearchScene({ elements }: { elements: Element[] }) {
+function BinarySearchScene({
+  elements,
+  allowPulse,
+}: {
+  elements: Element[];
+  allowPulse: boolean;
+}) {
   const spacing = 1.2;
   const startX = (-(elements.length - 1) * spacing) / 2;
 
@@ -123,6 +139,7 @@ function BinarySearchScene({ elements }: { elements: Element[] }) {
           position={[startX + index * spacing, 0, 0]}
           value={element.value}
           status={element.status}
+          allowPulse={allowPulse}
         />
       ))}
 
@@ -137,12 +154,25 @@ function BinarySearchScene({ elements }: { elements: Element[] }) {
   );
 }
 
-export default function BinarySearchVisualization() {
+interface BinarySearchVisualizationProps {
+  motionMode?: MotionMode;
+  defaultPlaying?: boolean;
+}
+
+export default function BinarySearchVisualization({
+  motionMode,
+  defaultPlaying = false,
+}: BinarySearchVisualizationProps) {
+  const effectiveMotionMode = useEffectiveMotionMode(motionMode);
+  const allowPulse = effectiveMotionMode === 'full';
+  const isCanvasDisabled = effectiveMotionMode === 'off';
   const [elements, setElements] = useState<Element[]>([]);
   const [target, setTarget] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [message, setMessage] = useState('');
   const [speed, setSpeed] = useState(800);
+  const previousPlayingRef = useRef(isPlaying);
+  const hasAutoStartedRef = useRef(false);
 
   // Initialize sorted array
   const initializeArray = () => {
@@ -164,6 +194,15 @@ export default function BinarySearchVisualization() {
   useEffect(() => {
     initializeArray();
   }, []);
+
+  useEffect(() => {
+    if (defaultPlaying && elements.length > 0 && !hasAutoStartedRef.current) {
+      hasAutoStartedRef.current = true;
+      void binarySearch();
+    }
+    // Trigger auto-start once only after data is ready.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultPlaying, elements.length]);
 
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
@@ -231,8 +270,33 @@ export default function BinarySearchVisualization() {
     setIsPlaying(false);
   };
 
+  useEffect(() => {
+    if (isPlaying && !previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationStarted, {
+        component_name: 'BinarySearchVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    if (!isPlaying && previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationPaused, {
+        component_name: 'BinarySearchVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    previousPlayingRef.current = isPlaying;
+  }, [effectiveMotionMode, isPlaying]);
+
   return (
-    <div className="w-full space-y-4">
+    <VisualizationFrame
+      title="이진 탐색 시각화"
+      controlsHint="목표 값을 설정하고 탐색 시작을 누르면 포인터가 이동하는 과정을 따라갈 수 있습니다."
+      motionMode={effectiveMotionMode}
+      statusText={isPlaying ? '탐색 진행 중' : '대기 중'}
+    >
       {/* Controls */}
       <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-xl p-6 shadow-xl">
         <div className="space-y-4">
@@ -327,11 +391,18 @@ export default function BinarySearchVisualization() {
 
       {/* Canvas */}
       <div className="w-full h-[500px] bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl overflow-hidden shadow-2xl">
-        <Canvas camera={{ position: [0, 3, 12], fov: 50 }}>
-          <color attach="background" args={['#0f172a']} />
-          <BinarySearchScene elements={elements} />
-        </Canvas>
+        {isCanvasDisabled ? (
+          <VisualizationFallback
+            title="3D 뷰가 꺼져 있습니다"
+            description="모션 모드가 꺼짐 상태라 3D 렌더링을 생략했습니다. 상단 모션 버튼에서 자동 또는 축소 모드로 변경하면 다시 볼 수 있습니다."
+          />
+        ) : (
+          <Canvas dpr={[1, 1.5]} camera={{ position: [0, 3, 12], fov: 50 }}>
+            <color attach="background" args={['#0f172a']} />
+            <BinarySearchScene elements={elements} allowPulse={allowPulse} />
+          </Canvas>
+        )}
       </div>
-    </div>
+    </VisualizationFrame>
   );
 }

--- a/src/components/visualization/DPVisualization.tsx
+++ b/src/components/visualization/DPVisualization.tsx
@@ -4,6 +4,14 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text } from '@react-three/drei';
 import * as THREE from 'three';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+import {
+  type MotionMode,
+  useEffectiveMotionMode,
+} from '@/shared/motion/model/motion-mode';
+import VisualizationFrame, {
+  VisualizationFallback,
+} from './VisualizationFrame';
 
 interface DPCell {
   index: number;
@@ -17,16 +25,18 @@ function Cell3D({
   index,
   value,
   status,
+  allowPulse,
 }: {
   position: [number, number, number];
   index: number;
   value: number | null;
   status: string;
+  allowPulse: boolean;
 }) {
   const meshRef = useRef<THREE.Mesh>(null);
 
   useFrame(() => {
-    if (meshRef.current && status === 'calculating') {
+    if (meshRef.current && status === 'calculating' && allowPulse) {
       const scale = 1 + Math.sin(Date.now() * 0.01) * 0.15;
       meshRef.current.scale.setScalar(scale);
     } else if (meshRef.current) {
@@ -113,11 +123,13 @@ function DPScene({
   showArrows,
   arrowFrom,
   arrowTo,
+  allowPulse,
 }: {
   cells: DPCell[];
   showArrows: boolean;
   arrowFrom: number[];
   arrowTo: number;
+  allowPulse: boolean;
 }) {
   const spacing = 1.3;
   const startX = (-(cells.length - 1) * spacing) / 2;
@@ -136,6 +148,7 @@ function DPScene({
           index={cell.index}
           value={cell.value}
           status={cell.status}
+          allowPulse={allowPulse}
         />
       ))}
 
@@ -170,7 +183,18 @@ function DPScene({
   );
 }
 
-export default function DPVisualization() {
+interface DPVisualizationProps {
+  motionMode?: MotionMode;
+  defaultPlaying?: boolean;
+}
+
+export default function DPVisualization({
+  motionMode,
+  defaultPlaying = false,
+}: DPVisualizationProps) {
+  const effectiveMotionMode = useEffectiveMotionMode(motionMode);
+  const allowPulse = effectiveMotionMode === 'full';
+  const isCanvasDisabled = effectiveMotionMode === 'off';
   const [n, setN] = useState(8);
   const [cells, setCells] = useState<DPCell[]>([]);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -179,6 +203,8 @@ export default function DPVisualization() {
   const [showArrows, setShowArrows] = useState(false);
   const [arrowFrom, setArrowFrom] = useState<number[]>([]);
   const [arrowTo, setArrowTo] = useState(-1);
+  const previousPlayingRef = useRef(isPlaying);
+  const hasAutoStartedRef = useRef(false);
 
   // Initialize DP table
   const initializeTable = () => {
@@ -201,6 +227,15 @@ export default function DPVisualization() {
   useEffect(() => {
     initializeTable();
   }, [n]);
+
+  useEffect(() => {
+    if (defaultPlaying && cells.length > 0 && !hasAutoStartedRef.current) {
+      hasAutoStartedRef.current = true;
+      void fibonacci();
+    }
+    // Trigger auto-start once only after data is ready.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultPlaying, cells.length]);
 
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
@@ -262,8 +297,33 @@ export default function DPVisualization() {
     setIsPlaying(false);
   };
 
+  useEffect(() => {
+    if (isPlaying && !previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationStarted, {
+        component_name: 'DPVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    if (!isPlaying && previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationPaused, {
+        component_name: 'DPVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    previousPlayingRef.current = isPlaying;
+  }, [effectiveMotionMode, isPlaying]);
+
   return (
-    <div className="w-full space-y-4">
+    <VisualizationFrame
+      title="동적 프로그래밍 시각화"
+      controlsHint="N 값을 바꾸고 시작하면 피보나치 DP 테이블이 채워지는 과정을 확인할 수 있습니다."
+      motionMode={effectiveMotionMode}
+      statusText={isPlaying ? '계산 진행 중' : '대기 중'}
+    >
       {/* Controls */}
       <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-xl p-6 shadow-xl">
         <div className="space-y-4">
@@ -365,16 +425,24 @@ export default function DPVisualization() {
 
       {/* Canvas */}
       <div className="w-full h-[500px] bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl overflow-hidden shadow-2xl">
-        <Canvas camera={{ position: [0, 3, 12], fov: 50 }}>
-          <color attach="background" args={['#0f172a']} />
-          <DPScene
-            cells={cells}
-            showArrows={showArrows}
-            arrowFrom={arrowFrom}
-            arrowTo={arrowTo}
+        {isCanvasDisabled ? (
+          <VisualizationFallback
+            title="3D 뷰가 꺼져 있습니다"
+            description="모션 모드가 꺼짐 상태라 3D 렌더링을 생략했습니다. 상단 모션 버튼에서 자동 또는 축소 모드로 변경하면 다시 볼 수 있습니다."
           />
-        </Canvas>
+        ) : (
+          <Canvas dpr={[1, 1.5]} camera={{ position: [0, 3, 12], fov: 50 }}>
+            <color attach="background" args={['#0f172a']} />
+            <DPScene
+              cells={cells}
+              showArrows={showArrows}
+              arrowFrom={arrowFrom}
+              arrowTo={arrowTo}
+              allowPulse={allowPulse}
+            />
+          </Canvas>
+        )}
       </div>
-    </div>
+    </VisualizationFrame>
   );
 }

--- a/src/components/visualization/GraphTraversalVisualization.tsx
+++ b/src/components/visualization/GraphTraversalVisualization.tsx
@@ -4,6 +4,14 @@ import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text, Line } from '@react-three/drei';
 import * as THREE from 'three';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+import {
+  type MotionMode,
+  useEffectiveMotionMode,
+} from '@/shared/motion/model/motion-mode';
+import VisualizationFrame, {
+  VisualizationFallback,
+} from './VisualizationFrame';
 
 // Graph node structure
 interface GraphNode {
@@ -19,12 +27,14 @@ function Node({
   isVisited,
   isActive,
   isQueued,
+  allowPulse,
 }: {
   position: [number, number, number];
   label: string;
   isVisited: boolean;
   isActive: boolean;
   isQueued: boolean;
+  allowPulse: boolean;
 }) {
   const meshRef = useRef<THREE.Mesh>(null);
   const [hovered, setHovered] = useState(false);
@@ -32,7 +42,7 @@ function Node({
   useFrame(() => {
     if (meshRef.current) {
       // Pulse animation for active node
-      if (isActive) {
+      if (isActive && allowPulse) {
         const scale = 1 + Math.sin(Date.now() * 0.005) * 0.2;
         meshRef.current.scale.setScalar(scale);
       } else {
@@ -111,12 +121,14 @@ function GraphScene({
   activeNode,
   queuedNodes,
   traversedEdges,
+  allowPulse,
 }: {
   nodes: GraphNode[];
   visitedNodes: Set<number>;
   activeNode: number | null;
   queuedNodes: Set<number>;
   traversedEdges: Set<string>;
+  allowPulse: boolean;
 }) {
   return (
     <>
@@ -155,6 +167,7 @@ function GraphScene({
           isVisited={visitedNodes.has(node.id)}
           isActive={activeNode === node.id}
           isQueued={queuedNodes.has(node.id)}
+          allowPulse={allowPulse}
         />
       ))}
 
@@ -169,16 +182,28 @@ function GraphScene({
   );
 }
 
+interface GraphTraversalVisualizationProps {
+  motionMode?: MotionMode;
+  defaultPlaying?: boolean;
+}
+
 // Main visualization component
-export default function GraphTraversalVisualization() {
+export default function GraphTraversalVisualization({
+  motionMode,
+  defaultPlaying = false,
+}: GraphTraversalVisualizationProps) {
+  const effectiveMotionMode = useEffectiveMotionMode(motionMode);
+  const allowPulse = effectiveMotionMode === 'full';
+  const isCanvasDisabled = effectiveMotionMode === 'off';
   const [algorithm, setAlgorithm] = useState<'DFS' | 'BFS'>('DFS');
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(defaultPlaying);
   const [visitedNodes, setVisitedNodes] = useState<Set<number>>(new Set());
   const [activeNode, setActiveNode] = useState<number | null>(null);
   const [queuedNodes, setQueuedNodes] = useState<Set<number>>(new Set());
   const [traversedEdges, setTraversedEdges] = useState<Set<string>>(new Set());
   const [currentStep, setCurrentStep] = useState(0);
   const [traversalPath, setTraversalPath] = useState<number[]>([]);
+  const previousPlayingRef = useRef(isPlaying);
 
   // Define graph structure (tree-like graph)
   const nodes: GraphNode[] = useMemo(
@@ -263,6 +288,36 @@ export default function GraphTraversalVisualization() {
     }
   };
 
+  useEffect(() => {
+    if (defaultPlaying && traversalPath.length === 0) {
+      togglePlayPause();
+    }
+    // Only runs when autoplay is requested for the initial render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultPlaying]);
+
+  useEffect(() => {
+    if (isPlaying && !previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationStarted, {
+        component_name: 'GraphTraversalVisualization',
+        algorithm,
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    if (!isPlaying && previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationPaused, {
+        component_name: 'GraphTraversalVisualization',
+        algorithm,
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    previousPlayingRef.current = isPlaying;
+  }, [algorithm, effectiveMotionMode, isPlaying]);
+
   // Handle algorithm change
   const handleAlgorithmChange = (newAlgorithm: 'DFS' | 'BFS') => {
     setAlgorithm(newAlgorithm);
@@ -314,8 +369,13 @@ export default function GraphTraversalVisualization() {
   }, [isPlaying, currentStep, traversalPath, algorithm]);
 
   return (
-    <div className="w-full space-y-4">
-      {/* Controls & Legend */}
+    <VisualizationFrame
+      title="그래프 순회 시각화"
+      controlsHint="DFS/BFS를 선택하고 재생을 누르면 탐색 과정을 단계별로 확인할 수 있습니다."
+      motionMode={effectiveMotionMode}
+      isPlaying={isPlaying}
+      statusText={isPlaying ? '탐색 진행 중' : '대기 중'}
+    >
       <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-xl p-6 shadow-xl">
         <div className="space-y-6">
           <div className="flex flex-wrap gap-4 items-center justify-between">
@@ -426,17 +486,25 @@ export default function GraphTraversalVisualization() {
 
       {/* Canvas */}
       <div className="w-full h-[500px] bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl overflow-hidden shadow-2xl">
-        <Canvas camera={{ position: [0, 0, 12], fov: 50 }}>
-          <color attach="background" args={['#0f172a']} />
-          <GraphScene
-            nodes={nodes}
-            visitedNodes={visitedNodes}
-            activeNode={activeNode}
-            queuedNodes={queuedNodes}
-            traversedEdges={traversedEdges}
+        {isCanvasDisabled ? (
+          <VisualizationFallback
+            title="3D 뷰가 꺼져 있습니다"
+            description="모션 모드가 꺼짐 상태라 3D 렌더링을 생략했습니다. 상단 모션 버튼에서 자동 또는 축소 모드로 변경하면 다시 볼 수 있습니다."
           />
-        </Canvas>
+        ) : (
+          <Canvas dpr={[1, 1.5]} camera={{ position: [0, 0, 12], fov: 50 }}>
+            <color attach="background" args={['#0f172a']} />
+            <GraphScene
+              nodes={nodes}
+              visitedNodes={visitedNodes}
+              activeNode={activeNode}
+              queuedNodes={queuedNodes}
+              traversedEdges={traversedEdges}
+              allowPulse={allowPulse}
+            />
+          </Canvas>
+        )}
       </div>
-    </div>
+    </VisualizationFrame>
   );
 }

--- a/src/components/visualization/SlidingWindowVisualization.tsx
+++ b/src/components/visualization/SlidingWindowVisualization.tsx
@@ -4,6 +4,14 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text } from '@react-three/drei';
 import * as THREE from 'three';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+import {
+  type MotionMode,
+  useEffectiveMotionMode,
+} from '@/shared/motion/model/motion-mode';
+import VisualizationFrame, {
+  VisualizationFallback,
+} from './VisualizationFrame';
 
 interface Element {
   value: number;
@@ -15,15 +23,17 @@ function Box3DWindow({
   position,
   value,
   status,
+  allowPulse,
 }: {
   position: [number, number, number];
   value: number;
   status: string;
+  allowPulse: boolean;
 }) {
   const meshRef = useRef<THREE.Mesh>(null);
 
   useFrame(() => {
-    if (meshRef.current && status === 'max-window') {
+    if (meshRef.current && status === 'max-window' && allowPulse) {
       const scale = 1 + Math.sin(Date.now() * 0.008) * 0.12;
       meshRef.current.scale.setScalar(scale);
     } else if (meshRef.current) {
@@ -124,10 +134,12 @@ function SlidingWindowScene({
   elements,
   windowStart,
   windowSize,
+  allowPulse,
 }: {
   elements: Element[];
   windowStart: number;
   windowSize: number;
+  allowPulse: boolean;
 }) {
   const spacing = 1.2;
   const startX = (-(elements.length - 1) * spacing) / 2;
@@ -154,6 +166,7 @@ function SlidingWindowScene({
           position={[startX + index * spacing, 0, 0]}
           value={element.value}
           status={element.status}
+          allowPulse={allowPulse}
         />
       ))}
 
@@ -168,7 +181,18 @@ function SlidingWindowScene({
   );
 }
 
-export default function SlidingWindowVisualization() {
+interface SlidingWindowVisualizationProps {
+  motionMode?: MotionMode;
+  defaultPlaying?: boolean;
+}
+
+export default function SlidingWindowVisualization({
+  motionMode,
+  defaultPlaying = false,
+}: SlidingWindowVisualizationProps) {
+  const effectiveMotionMode = useEffectiveMotionMode(motionMode);
+  const allowPulse = effectiveMotionMode === 'full';
+  const isCanvasDisabled = effectiveMotionMode === 'off';
   const [elements, setElements] = useState<Element[]>([]);
   const [windowSize, setWindowSize] = useState(3);
   const [windowStart, setWindowStart] = useState(-1);
@@ -177,6 +201,8 @@ export default function SlidingWindowVisualization() {
   const [maxSum, setMaxSum] = useState(0);
   const [maxWindowStart, setMaxWindowStart] = useState(-1);
   const [speed, setSpeed] = useState(800);
+  const previousPlayingRef = useRef(isPlaying);
+  const hasAutoStartedRef = useRef(false);
 
   // Initialize array
   const initializeArray = () => {
@@ -198,6 +224,15 @@ export default function SlidingWindowVisualization() {
   useEffect(() => {
     initializeArray();
   }, []);
+
+  useEffect(() => {
+    if (defaultPlaying && elements.length > 0 && !hasAutoStartedRef.current) {
+      hasAutoStartedRef.current = true;
+      void slidingWindow();
+    }
+    // Trigger auto-start once only after data is ready.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultPlaying, elements.length]);
 
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
@@ -281,8 +316,33 @@ export default function SlidingWindowVisualization() {
     setIsPlaying(false);
   };
 
+  useEffect(() => {
+    if (isPlaying && !previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationStarted, {
+        component_name: 'SlidingWindowVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    if (!isPlaying && previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationPaused, {
+        component_name: 'SlidingWindowVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    previousPlayingRef.current = isPlaying;
+  }, [effectiveMotionMode, isPlaying]);
+
   return (
-    <div className="w-full space-y-4">
+    <VisualizationFrame
+      title="슬라이딩 윈도우 시각화"
+      controlsHint="윈도우 크기를 설정하고 시작하면 윈도우 이동과 최대 합 갱신을 확인할 수 있습니다."
+      motionMode={effectiveMotionMode}
+      statusText={isPlaying ? '탐색 진행 중' : '대기 중'}
+    >
       {/* Controls */}
       <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-xl p-6 shadow-xl">
         <div className="space-y-4">
@@ -406,15 +466,23 @@ export default function SlidingWindowVisualization() {
 
       {/* Canvas */}
       <div className="w-full h-[500px] bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl overflow-hidden shadow-2xl">
-        <Canvas camera={{ position: [0, 3, 12], fov: 50 }}>
-          <color attach="background" args={['#0f172a']} />
-          <SlidingWindowScene
-            elements={elements}
-            windowStart={windowStart}
-            windowSize={windowSize}
+        {isCanvasDisabled ? (
+          <VisualizationFallback
+            title="3D 뷰가 꺼져 있습니다"
+            description="모션 모드가 꺼짐 상태라 3D 렌더링을 생략했습니다. 상단 모션 버튼에서 자동 또는 축소 모드로 변경하면 다시 볼 수 있습니다."
           />
-        </Canvas>
+        ) : (
+          <Canvas dpr={[1, 1.5]} camera={{ position: [0, 3, 12], fov: 50 }}>
+            <color attach="background" args={['#0f172a']} />
+            <SlidingWindowScene
+              elements={elements}
+              windowStart={windowStart}
+              windowSize={windowSize}
+              allowPulse={allowPulse}
+            />
+          </Canvas>
+        )}
       </div>
-    </div>
+    </VisualizationFrame>
   );
 }

--- a/src/components/visualization/SortingVisualization.tsx
+++ b/src/components/visualization/SortingVisualization.tsx
@@ -4,6 +4,14 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text } from '@react-three/drei';
 import * as THREE from 'three';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+import {
+  type MotionMode,
+  useEffectiveMotionMode,
+} from '@/shared/motion/model/motion-mode';
+import VisualizationFrame, {
+  VisualizationFallback,
+} from './VisualizationFrame';
 
 interface Bar {
   value: number;
@@ -15,16 +23,18 @@ function Bar3D({
   position,
   height,
   status,
+  allowPulse,
 }: {
   position: [number, number, number];
   height: number;
   status: string;
+  allowPulse: boolean;
 }) {
   const meshRef = useRef<THREE.Mesh>(null);
 
   useFrame(() => {
     if (meshRef.current) {
-      if (status === 'swapping') {
+      if (status === 'swapping' && allowPulse) {
         const scale = 1 + Math.sin(Date.now() * 0.01) * 0.1;
         meshRef.current.scale.set(1, scale, 1);
       } else {
@@ -70,7 +80,13 @@ function Bar3D({
 }
 
 // Scene component
-function SortingScene({ bars }: { bars: Bar[] }) {
+function SortingScene({
+  bars,
+  allowPulse,
+}: {
+  bars: Bar[];
+  allowPulse: boolean;
+}) {
   const spacing = 1.2;
   const startX = (-(bars.length - 1) * spacing) / 2;
 
@@ -86,6 +102,7 @@ function SortingScene({ bars }: { bars: Bar[] }) {
           position={[startX + index * spacing, 0, 0]}
           height={bar.value}
           status={bar.status}
+          allowPulse={allowPulse}
         />
       ))}
 
@@ -100,13 +117,26 @@ function SortingScene({ bars }: { bars: Bar[] }) {
   );
 }
 
-export default function SortingVisualization() {
+interface SortingVisualizationProps {
+  motionMode?: MotionMode;
+  defaultPlaying?: boolean;
+}
+
+export default function SortingVisualization({
+  motionMode,
+  defaultPlaying = false,
+}: SortingVisualizationProps) {
+  const effectiveMotionMode = useEffectiveMotionMode(motionMode);
+  const allowPulse = effectiveMotionMode === 'full';
+  const isCanvasDisabled = effectiveMotionMode === 'off';
   const [algorithm, setAlgorithm] = useState<'quick' | 'merge' | 'heap'>(
     'quick'
   );
   const [bars, setBars] = useState<Bar[]>([]);
   const [isPlaying, setIsPlaying] = useState(false);
   const [speed, setSpeed] = useState(500);
+  const previousPlayingRef = useRef(isPlaying);
+  const hasAutoStartedRef = useRef(false);
 
   // Initialize random array
   const initializeArray = () => {
@@ -124,6 +154,15 @@ export default function SortingVisualization() {
   useEffect(() => {
     initializeArray();
   }, []);
+
+  useEffect(() => {
+    if (defaultPlaying && bars.length > 0 && !hasAutoStartedRef.current) {
+      hasAutoStartedRef.current = true;
+      void handleStart();
+    }
+    // Trigger auto-start once only after data is ready.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultPlaying, bars.length]);
 
   // Quick Sort
   const quickSort = async () => {
@@ -333,8 +372,35 @@ export default function SortingVisualization() {
     initializeArray();
   };
 
+  useEffect(() => {
+    if (isPlaying && !previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationStarted, {
+        component_name: 'SortingVisualization',
+        algorithm,
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    if (!isPlaying && previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationPaused, {
+        component_name: 'SortingVisualization',
+        algorithm,
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    previousPlayingRef.current = isPlaying;
+  }, [algorithm, effectiveMotionMode, isPlaying]);
+
   return (
-    <div className="w-full space-y-4">
+    <VisualizationFrame
+      title="정렬 알고리즘 시각화"
+      controlsHint="알고리즘과 속도를 설정한 뒤 시작하면 비교/교환 과정을 단계별로 보여줍니다."
+      motionMode={effectiveMotionMode}
+      statusText={isPlaying ? '정렬 진행 중' : '대기 중'}
+    >
       {/* Controls */}
       <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-xl p-6 shadow-xl">
         <div className="flex flex-wrap gap-4 items-center justify-between">
@@ -435,11 +501,18 @@ export default function SortingVisualization() {
 
       {/* Canvas */}
       <div className="w-full h-[500px] bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl overflow-hidden shadow-2xl">
-        <Canvas camera={{ position: [0, 5, 12], fov: 50 }}>
-          <color attach="background" args={['#0f172a']} />
-          <SortingScene bars={bars} />
-        </Canvas>
+        {isCanvasDisabled ? (
+          <VisualizationFallback
+            title="3D 뷰가 꺼져 있습니다"
+            description="모션 모드가 꺼짐 상태라 3D 렌더링을 생략했습니다. 상단 모션 버튼에서 자동 또는 축소 모드로 변경하면 다시 볼 수 있습니다."
+          />
+        ) : (
+          <Canvas dpr={[1, 1.5]} camera={{ position: [0, 5, 12], fov: 50 }}>
+            <color attach="background" args={['#0f172a']} />
+            <SortingScene bars={bars} allowPulse={allowPulse} />
+          </Canvas>
+        )}
       </div>
-    </div>
+    </VisualizationFrame>
   );
 }

--- a/src/components/visualization/TwoPointerVisualization.tsx
+++ b/src/components/visualization/TwoPointerVisualization.tsx
@@ -4,6 +4,14 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text } from '@react-three/drei';
 import * as THREE from 'three';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+import {
+  type MotionMode,
+  useEffectiveMotionMode,
+} from '@/shared/motion/model/motion-mode';
+import VisualizationFrame, {
+  VisualizationFallback,
+} from './VisualizationFrame';
 
 interface Element {
   value: number;
@@ -21,10 +29,12 @@ function Box3DWithPointer({
   position,
   value,
   status,
+  allowPulse,
 }: {
   position: [number, number, number];
   value: number;
   status: string;
+  allowPulse: boolean;
 }) {
   const meshRef = useRef<THREE.Mesh>(null);
 
@@ -33,7 +43,8 @@ function Box3DWithPointer({
       meshRef.current &&
       (status === 'left-pointer' ||
         status === 'right-pointer' ||
-        status === 'both-pointers')
+        status === 'both-pointers') &&
+      allowPulse
     ) {
       const scale = 1 + Math.sin(Date.now() * 0.008) * 0.1;
       meshRef.current.scale.setScalar(scale);
@@ -123,7 +134,13 @@ function Box3DWithPointer({
 }
 
 // Scene component
-function TwoPointerScene({ elements }: { elements: Element[] }) {
+function TwoPointerScene({
+  elements,
+  allowPulse,
+}: {
+  elements: Element[];
+  allowPulse: boolean;
+}) {
   const spacing = 1.2;
   const startX = (-(elements.length - 1) * spacing) / 2;
 
@@ -139,6 +156,7 @@ function TwoPointerScene({ elements }: { elements: Element[] }) {
           position={[startX + index * spacing, 0, 0]}
           value={element.value}
           status={element.status}
+          allowPulse={allowPulse}
         />
       ))}
 
@@ -153,12 +171,25 @@ function TwoPointerScene({ elements }: { elements: Element[] }) {
   );
 }
 
-export default function TwoPointerVisualization() {
+interface TwoPointerVisualizationProps {
+  motionMode?: MotionMode;
+  defaultPlaying?: boolean;
+}
+
+export default function TwoPointerVisualization({
+  motionMode,
+  defaultPlaying = false,
+}: TwoPointerVisualizationProps) {
+  const effectiveMotionMode = useEffectiveMotionMode(motionMode);
+  const allowPulse = effectiveMotionMode === 'full';
+  const isCanvasDisabled = effectiveMotionMode === 'off';
   const [elements, setElements] = useState<Element[]>([]);
   const [target, setTarget] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [message, setMessage] = useState('');
   const [speed, setSpeed] = useState(800);
+  const previousPlayingRef = useRef(isPlaying);
+  const hasAutoStartedRef = useRef(false);
 
   // Initialize sorted array
   const initializeArray = () => {
@@ -176,6 +207,15 @@ export default function TwoPointerVisualization() {
   useEffect(() => {
     initializeArray();
   }, []);
+
+  useEffect(() => {
+    if (defaultPlaying && elements.length > 0 && !hasAutoStartedRef.current) {
+      hasAutoStartedRef.current = true;
+      void twoPointerSearch();
+    }
+    // Trigger auto-start once only after data is ready.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultPlaying, elements.length]);
 
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
@@ -244,8 +284,33 @@ export default function TwoPointerVisualization() {
     setIsPlaying(false);
   };
 
+  useEffect(() => {
+    if (isPlaying && !previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationStarted, {
+        component_name: 'TwoPointerVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    if (!isPlaying && previousPlayingRef.current) {
+      trackEvent(AnalyticsEvents.visualizationPaused, {
+        component_name: 'TwoPointerVisualization',
+        motion_mode: effectiveMotionMode,
+        surface: 'blog_post',
+      });
+    }
+
+    previousPlayingRef.current = isPlaying;
+  }, [effectiveMotionMode, isPlaying]);
+
   return (
-    <div className="w-full space-y-4">
+    <VisualizationFrame
+      title="투 포인터 시각화"
+      controlsHint="목표 합을 지정하고 탐색 시작을 누르면 양 끝 포인터 이동 과정을 확인할 수 있습니다."
+      motionMode={effectiveMotionMode}
+      statusText={isPlaying ? '탐색 진행 중' : '대기 중'}
+    >
       {/* Controls */}
       <div className="bg-gradient-to-br from-slate-800 to-slate-900 rounded-xl p-6 shadow-xl">
         <div className="space-y-4">
@@ -315,8 +380,8 @@ export default function TwoPointerVisualization() {
           <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-3">
             <p className="text-blue-300 text-sm">
               <span className="tossface mr-1">💡</span>
-              <strong>투 포인터 알고리즘:</strong> 정렬된 배열에서 두
-              포인터를 양 끝에서 시작하여, 합이 목표값보다 작으면 왼쪽 포인터를
+              <strong>투 포인터 알고리즘:</strong> 정렬된 배열에서 두 포인터를
+              양 끝에서 시작하여, 합이 목표값보다 작으면 왼쪽 포인터를
               오른쪽으로, 크면 오른쪽 포인터를 왼쪽으로 이동합니다.
             </p>
           </div>
@@ -349,11 +414,18 @@ export default function TwoPointerVisualization() {
 
       {/* Canvas */}
       <div className="w-full h-[500px] bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl overflow-hidden shadow-2xl">
-        <Canvas camera={{ position: [0, 3, 12], fov: 50 }}>
-          <color attach="background" args={['#0f172a']} />
-          <TwoPointerScene elements={elements} />
-        </Canvas>
+        {isCanvasDisabled ? (
+          <VisualizationFallback
+            title="3D 뷰가 꺼져 있습니다"
+            description="모션 모드가 꺼짐 상태라 3D 렌더링을 생략했습니다. 상단 모션 버튼에서 자동 또는 축소 모드로 변경하면 다시 볼 수 있습니다."
+          />
+        ) : (
+          <Canvas dpr={[1, 1.5]} camera={{ position: [0, 3, 12], fov: 50 }}>
+            <color attach="background" args={['#0f172a']} />
+            <TwoPointerScene elements={elements} allowPulse={allowPulse} />
+          </Canvas>
+        )}
       </div>
-    </div>
+    </VisualizationFrame>
   );
 }

--- a/src/components/visualization/VisualizationFrame.tsx
+++ b/src/components/visualization/VisualizationFrame.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import type {
+  EffectiveMotionMode,
+  MotionMode,
+} from '@/shared/motion/model/motion-mode';
+
+export interface VisualizationFrameProps {
+  title: string;
+  controlsHint: string;
+  motionMode: MotionMode | EffectiveMotionMode;
+  statusText?: string;
+  isPlaying?: boolean;
+  onTogglePlay?: () => void;
+  children: ReactNode;
+}
+
+const modeLabel: Record<MotionMode | EffectiveMotionMode, string> = {
+  auto: '자동',
+  full: '자동(전체)',
+  reduced: '축소',
+  off: '끔',
+};
+
+export default function VisualizationFrame({
+  title,
+  controlsHint,
+  motionMode,
+  statusText,
+  isPlaying,
+  onTogglePlay,
+  children,
+}: VisualizationFrameProps) {
+  return (
+    <div className="w-full space-y-4">
+      <div className="rounded-xl border border-[var(--color-grey-200)] bg-[var(--color-grey-50)] p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-base font-semibold text-[var(--color-grey-900)]">
+            {title}
+          </h3>
+
+          <div className="flex items-center gap-2">
+            <span className="rounded-full border border-[var(--color-grey-300)] bg-[var(--color-bg-primary)] px-2.5 py-1 text-xs font-medium text-[var(--color-grey-700)]">
+              모션 {modeLabel[motionMode] ?? modeLabel.auto}
+            </span>
+            {onTogglePlay && (
+              <button
+                type="button"
+                onClick={onTogglePlay}
+                className="rounded-lg border border-[var(--color-grey-300)] bg-[var(--color-bg-primary)] px-3 py-1.5 text-xs font-semibold text-[var(--color-grey-800)] hover:bg-[var(--color-grey-100)]"
+              >
+                {isPlaying ? '일시정지' : '재생'}
+              </button>
+            )}
+          </div>
+        </div>
+
+        <p className="mt-2 text-sm text-[var(--color-grey-600)]">
+          {controlsHint}
+        </p>
+        {statusText && (
+          <p className="mt-2 text-xs font-medium text-[var(--color-toss-blue)]">
+            현재 상태: {statusText}
+          </p>
+        )}
+      </div>
+
+      {children}
+    </div>
+  );
+}
+
+interface VisualizationFallbackProps {
+  title: string;
+  description: string;
+}
+
+export function VisualizationFallback({
+  title,
+  description,
+}: VisualizationFallbackProps) {
+  return (
+    <div className="rounded-xl border border-[var(--color-grey-200)] bg-[var(--color-bg-primary)] p-6">
+      <h4 className="text-sm font-semibold text-[var(--color-grey-900)]">
+        {title}
+      </h4>
+      <p className="mt-2 text-sm text-[var(--color-grey-600)]">{description}</p>
+    </div>
+  );
+}

--- a/src/components/visualization/index.ts
+++ b/src/components/visualization/index.ts
@@ -4,3 +4,4 @@ export { default as GraphTraversalVisualization } from './GraphTraversalVisualiz
 export { default as SlidingWindowVisualization } from './SlidingWindowVisualization';
 export { default as SortingVisualization } from './SortingVisualization';
 export { default as TwoPointerVisualization } from './TwoPointerVisualization';
+export { default as VisualizationFrame } from './VisualizationFrame';

--- a/tests/e2e/accessibility/reduced-motion.spec.ts
+++ b/tests/e2e/accessibility/reduced-motion.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+const VISUALIZATION_POST_PATH = '/blog/algorithm-visualization';
+
+test.describe('Reduced motion preference', () => {
+  test('prefers-reduced-motion 환경에서 축소 모션 상태를 반영한다', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto(VISUALIZATION_POST_PATH);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('모션 축소').first()).toBeVisible();
+  });
+
+  test('모션 모드를 꺼짐으로 전환하면 3D 캔버스를 대체 안내로 전환한다', async ({
+    page,
+  }) => {
+    await page.goto(VISUALIZATION_POST_PATH);
+    await page.waitForLoadState('networkidle');
+
+    const motionButton = page
+      .getByRole('button', { name: /모션 모드/ })
+      .first();
+
+    await motionButton.click(); // auto -> reduced
+    await motionButton.click(); // reduced -> off
+
+    await expect(page.getByText('3D 뷰가 꺼져 있습니다').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add `VisualizationFrame` with consistent control hint/status/motion badge
- apply frame to visualization components and add started/paused analytics events
- respect motion mode in visualizations (`reduced` cuts pulse, `off` shows text fallback)
- set default canvas DPR to `[1, 1.5]`
- add reduced-motion e2e scenario and UX guardrails documentation

## Test
- `npx playwright test tests/e2e/accessibility/reduced-motion.spec.ts --project=mobile-chrome`
