### PR TITLE
feat(blog-series): 시리즈 허브 UI 개편 및 클릭 추적 추가

### DIFF
--- a/src/features/blog/model/series-group.test.ts
+++ b/src/features/blog/model/series-group.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { FeedData } from '@/domains/post/model/types';
+import { getSeriesGroups, getSeriesSummaries } from './series-group';
+
+const posts: FeedData[] = [
+  {
+    slug: 'redis-2',
+    title: 'Redis 2',
+    description: 'Redis 심화',
+    date: '2026-02-03',
+    category: 'Series',
+    readingTime: 12,
+    series: { id: 'redis', title: 'Redis Deep Dive', order: 2 },
+  },
+  {
+    slug: 'go-1',
+    title: 'Go 1',
+    description: 'Go 시작',
+    date: '2026-02-05',
+    category: 'Series',
+    readingTime: 9,
+    series: { id: 'go', title: 'Go Mastery', order: 1 },
+  },
+  {
+    slug: 'redis-1',
+    title: 'Redis 1',
+    description: 'Redis 기초',
+    date: '2026-02-01',
+    category: 'Series',
+    readingTime: 10,
+    series: { id: 'redis', title: 'Redis Deep Dive', order: 1 },
+  },
+  {
+    slug: 'go-2',
+    title: 'Go 2',
+    description: 'Go 패턴',
+    date: '2026-02-06',
+    category: 'Series',
+    series: { id: 'go', title: 'Go Mastery', order: 2 },
+  },
+  {
+    slug: 'tech-note',
+    title: 'Tech Note',
+    description: '일반 글',
+    date: '2026-02-07',
+    category: 'Tech',
+  },
+];
+
+describe('series-group', () => {
+  it('returns summaries sorted by latest update date', () => {
+    const summaries = getSeriesSummaries(posts);
+
+    expect(summaries).toHaveLength(2);
+    expect(summaries[0].id).toBe('go');
+    expect(summaries[0].latestDate).toBe('2026-02-06');
+    expect(summaries[1].id).toBe('redis');
+    expect(summaries[1].latestDate).toBe('2026-02-03');
+  });
+
+  it('sorts episodes by order and calculates aggregate fields', () => {
+    const summaries = getSeriesSummaries(posts);
+    const redisSummary = summaries.find((summary) => summary.id === 'redis');
+
+    expect(redisSummary).toBeDefined();
+    if (!redisSummary) {
+      return;
+    }
+
+    expect(redisSummary.posts.map((post) => post.slug)).toEqual([
+      'redis-1',
+      'redis-2',
+    ]);
+    expect(redisSummary.firstPostSlug).toBe('redis-1');
+    expect(redisSummary.postCount).toBe(2);
+    expect(redisSummary.totalReadingMinutes).toBe(22);
+  });
+
+  it('keeps getSeriesGroups backward compatible', () => {
+    const groups = getSeriesGroups(posts);
+    const redisGroup = groups.find((group) => group.id === 'redis');
+
+    expect(redisGroup).toBeDefined();
+    if (!redisGroup) {
+      return;
+    }
+
+    expect(redisGroup.title).toBe('Redis Deep Dive');
+    expect(redisGroup.posts).toHaveLength(2);
+    expect(redisGroup.latestDate).toBe('2026-02-03');
+  });
+});

--- a/src/features/blog/model/series-group.ts
+++ b/src/features/blog/model/series-group.ts
@@ -7,7 +7,32 @@ export interface SeriesGroup {
   latestDate: string;
 }
 
-export function getSeriesGroups(posts: FeedData[]): SeriesGroup[] {
+export interface SeriesSummary {
+  id: string;
+  title: string;
+  posts: FeedData[];
+  latestDate: string;
+  firstPostSlug: string | null;
+  postCount: number;
+  totalReadingMinutes: number;
+}
+
+function sortSeriesPosts(posts: FeedData[]): FeedData[] {
+  return [...posts].sort((a, b) => (a.series?.order ?? 0) - (b.series?.order ?? 0));
+}
+
+function getLatestDate(posts: FeedData[]): string {
+  if (posts.length === 0) {
+    return '';
+  }
+
+  return posts.reduce(
+    (latest, post) => (post.date > latest ? post.date : latest),
+    posts[0].date
+  );
+}
+
+export function getSeriesSummaries(posts: FeedData[]): SeriesSummary[] {
   const groups = new Map<string, { title: string; posts: FeedData[] }>();
 
   posts.forEach((post) => {
@@ -27,13 +52,12 @@ export function getSeriesGroups(posts: FeedData[]): SeriesGroup[] {
 
   return Array.from(groups.entries())
     .map(([id, value]) => {
-      const sortedPosts = [...value.posts].sort(
-        (a, b) => (a.series?.order ?? 0) - (b.series?.order ?? 0)
-      );
-
-      const latestDate = sortedPosts.reduce(
-        (latest, post) => (post.date > latest ? post.date : latest),
-        sortedPosts[0]?.date ?? ''
+      const sortedPosts = sortSeriesPosts(value.posts);
+      const latestDate = getLatestDate(sortedPosts);
+      const firstPostSlug = sortedPosts[0]?.slug ?? null;
+      const totalReadingMinutes = sortedPosts.reduce(
+        (total, post) => total + (post.readingTime ?? 0),
+        0
       );
 
       return {
@@ -41,12 +65,34 @@ export function getSeriesGroups(posts: FeedData[]): SeriesGroup[] {
         title: value.title,
         posts: sortedPosts,
         latestDate,
+        firstPostSlug,
+        postCount: sortedPosts.length,
+        totalReadingMinutes,
       };
     })
-    .sort((a, b) => (a.latestDate < b.latestDate ? 1 : -1));
+    .sort((a, b) => {
+      if (a.latestDate === b.latestDate) {
+        return a.title.localeCompare(b.title, 'ko');
+      }
+
+      return a.latestDate < b.latestDate ? 1 : -1;
+    });
+}
+
+export function getSeriesGroups(posts: FeedData[]): SeriesGroup[] {
+  return getSeriesSummaries(posts).map(({ id, title, posts: groupedPosts, latestDate }) => ({
+    id,
+    title,
+    posts: groupedPosts,
+    latestDate,
+  }));
 }
 
 export function formatSeriesDate(date: string): string {
+  if (!date) {
+    return '날짜 미정';
+  }
+
   return new Date(date).toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',

--- a/src/features/blog/ui/components/SeriesHubCard.tsx
+++ b/src/features/blog/ui/components/SeriesHubCard.tsx
@@ -1,0 +1,71 @@
+import type { SeriesSummary } from '@/features/blog/model/series-group';
+import { formatSeriesDate } from '@/features/blog/model/series-group';
+import SeriesTrackedLink from './SeriesTrackedLink';
+
+interface SeriesHubCardProps {
+  summary: SeriesSummary;
+  seriesIndex: number;
+}
+
+export default function SeriesHubCard({ summary, seriesIndex }: SeriesHubCardProps) {
+  const metaText = `총 ${summary.postCount}편 · 총 ${summary.totalReadingMinutes}분 · 최근 업데이트 ${formatSeriesDate(summary.latestDate)}`;
+  const firstPostOrder = summary.posts[0]?.series?.order;
+
+  return (
+    <section className="rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-bg-primary)] p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <span className="inline-flex rounded-full border border-[var(--color-category-series-border)] bg-[var(--color-category-series-bg)] px-2 py-1 text-xs font-medium text-[var(--color-category-series-text)]">
+            Series
+          </span>
+          <h2 className="mt-2 text-xl font-semibold text-[var(--color-text-primary)]">
+            {summary.title}
+          </h2>
+          <p className="mt-1 text-sm text-[var(--color-text-tertiary)]">{metaText}</p>
+        </div>
+
+        {summary.firstPostSlug && (
+          <SeriesTrackedLink
+            href={`/blog/${summary.firstPostSlug}`}
+            target="series_hub_start"
+            seriesId={summary.id}
+            seriesTitle={summary.title}
+            postSlug={summary.firstPostSlug}
+            episodeOrder={firstPostOrder}
+            seriesIndex={seriesIndex}
+            className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] px-3 py-1.5 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-hover)] hover:text-[var(--color-text-primary)]"
+          >
+            첫 글부터 읽기
+            <span aria-hidden="true">→</span>
+          </SeriesTrackedLink>
+        )}
+      </div>
+
+      <ol className="mt-5 space-y-2">
+        {summary.posts.map((post) => {
+          const order = post.series?.order ?? 0;
+
+          return (
+            <li key={post.slug}>
+              <SeriesTrackedLink
+                href={`/blog/${post.slug}`}
+                target="series_hub_episode"
+                seriesId={summary.id}
+                seriesTitle={summary.title}
+                postSlug={post.slug}
+                episodeOrder={order}
+                seriesIndex={seriesIndex}
+                className="flex min-h-11 items-center gap-3 rounded-[var(--radius-sm)] px-3 py-2 text-sm text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-grey-50)] hover:text-[var(--color-text-primary)]"
+              >
+                <span className="w-6 text-[var(--color-text-tertiary)]">{order}.</span>
+                <span className="flex-1 truncate">{post.title}</span>
+              </SeriesTrackedLink>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+export type { SeriesHubCardProps };

--- a/src/features/blog/ui/components/SeriesHubList.tsx
+++ b/src/features/blog/ui/components/SeriesHubList.tsx
@@ -1,0 +1,22 @@
+import type { SeriesSummary } from '@/features/blog/model/series-group';
+import SeriesHubCard from './SeriesHubCard';
+
+interface SeriesHubListProps {
+  seriesSummaries: SeriesSummary[];
+}
+
+export default function SeriesHubList({ seriesSummaries }: SeriesHubListProps) {
+  return (
+    <div className="space-y-6">
+      {seriesSummaries.map((summary, index) => (
+        <SeriesHubCard
+          key={summary.id}
+          summary={summary}
+          seriesIndex={index}
+        />
+      ))}
+    </div>
+  );
+}
+
+export type { SeriesHubListProps };

--- a/src/features/blog/ui/components/SeriesTrackedLink.test.tsx
+++ b/src/features/blog/ui/components/SeriesTrackedLink.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import SeriesTrackedLink from './SeriesTrackedLink';
+
+const mockTrackEvent = vi.fn();
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    onClick,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+  }) => {
+    return (
+      <a
+        href={href}
+        onClick={(event) => {
+          event.preventDefault();
+          onClick?.(event);
+        }}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
+}));
+
+vi.mock('@/shared/analytics/lib/analytics', () => ({
+  AnalyticsEvents: {
+    click: 'click',
+  },
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+
+describe('SeriesTrackedLink', () => {
+  it('tracks start CTA click with expected payload', () => {
+    mockTrackEvent.mockClear();
+
+    render(
+      <SeriesTrackedLink
+        href="/blog/redis-1"
+        target="series_hub_start"
+        seriesId="redis"
+        seriesTitle="Redis Deep Dive"
+        postSlug="redis-1"
+        episodeOrder={1}
+        seriesIndex={0}
+      >
+        첫 글부터 읽기
+      </SeriesTrackedLink>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: '첫 글부터 읽기' }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith('click', {
+      target: 'series_hub_start',
+      series_id: 'redis',
+      series_title: 'Redis Deep Dive',
+      post_slug: 'redis-1',
+      episode_order: 1,
+      series_index: 0,
+    });
+  });
+
+  it('tracks episode click with episode metadata', () => {
+    mockTrackEvent.mockClear();
+
+    render(
+      <SeriesTrackedLink
+        href="/blog/redis-2"
+        target="series_hub_episode"
+        seriesId="redis"
+        seriesTitle="Redis Deep Dive"
+        postSlug="redis-2"
+        episodeOrder={2}
+        seriesIndex={1}
+      >
+        2. Redis 심화
+      </SeriesTrackedLink>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: '2. Redis 심화' }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith('click', {
+      target: 'series_hub_episode',
+      series_id: 'redis',
+      series_title: 'Redis Deep Dive',
+      post_slug: 'redis-2',
+      episode_order: 2,
+      series_index: 1,
+    });
+  });
+});

--- a/src/features/blog/ui/components/SeriesTrackedLink.tsx
+++ b/src/features/blog/ui/components/SeriesTrackedLink.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Link from 'next/link';
+import type { MouseEvent, ReactNode } from 'react';
+import { clsx } from 'clsx';
+import { AnalyticsEvents, trackEvent } from '@/shared/analytics/lib/analytics';
+
+type SeriesTrackedTarget = 'series_hub_start' | 'series_hub_episode';
+
+interface SeriesTrackedLinkProps {
+  href: string;
+  children: ReactNode;
+  className?: string;
+  target: SeriesTrackedTarget;
+  seriesId: string;
+  seriesTitle: string;
+  postSlug: string;
+  episodeOrder?: number;
+  seriesIndex: number;
+  ariaLabel?: string;
+}
+
+export default function SeriesTrackedLink({
+  href,
+  children,
+  className,
+  target,
+  seriesId,
+  seriesTitle,
+  postSlug,
+  episodeOrder,
+  seriesIndex,
+  ariaLabel,
+}: SeriesTrackedLinkProps) {
+  const handleClick = (_event: MouseEvent<HTMLAnchorElement>) => {
+    trackEvent(AnalyticsEvents.click, {
+      target,
+      series_id: seriesId,
+      series_title: seriesTitle,
+      post_slug: postSlug,
+      episode_order: episodeOrder,
+      series_index: seriesIndex,
+    });
+  };
+
+  return (
+    <Link
+      href={href}
+      className={clsx(className)}
+      onClick={handleClick}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export type { SeriesTrackedTarget, SeriesTrackedLinkProps };

--- a/src/features/blog/ui/components/index.ts
+++ b/src/features/blog/ui/components/index.ts
@@ -18,4 +18,13 @@ export { MermaidDiagram } from './MermaidDiagram';
 export { ScrollWorkflow } from './ScrollWorkflow';
 
 export { SeriesNavigation } from './SeriesNavigation';
+export { default as SeriesHubCard } from './SeriesHubCard';
+export type { SeriesHubCardProps } from './SeriesHubCard';
+export { default as SeriesHubList } from './SeriesHubList';
+export type { SeriesHubListProps } from './SeriesHubList';
+export { default as SeriesTrackedLink } from './SeriesTrackedLink';
+export type {
+  SeriesTrackedLinkProps,
+  SeriesTrackedTarget,
+} from './SeriesTrackedLink';
 export { default as ViewCounter } from './ViewCounter';

--- a/src/features/blog/ui/pages/SeriesPage.test.tsx
+++ b/src/features/blog/ui/pages/SeriesPage.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { FeedData } from '@/domains/post/model/types';
+import type { SeriesSummary } from '@/features/blog/model/series-group';
+import SeriesPage from './SeriesPage';
+
+const mockGetSortedFeedData = vi.fn<() => FeedData[]>(() => []);
+const mockGetSeriesSummaries = vi.fn<(posts: FeedData[]) => SeriesSummary[]>(() => []);
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/shared/layout', () => ({
+  Header: () => <div data-testid="mock-header" />,
+  Container: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/features/blog/services/post-repository', () => ({
+  getSortedFeedData: () => mockGetSortedFeedData(),
+}));
+
+vi.mock('@/features/blog/model/series-group', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/features/blog/model/series-group')
+  >('@/features/blog/model/series-group');
+
+  return {
+    ...actual,
+    getSeriesSummaries: (posts: FeedData[]) => mockGetSeriesSummaries(posts),
+  };
+});
+
+describe('SeriesPage', () => {
+  it('renders series cards and summary stats', () => {
+    mockGetSortedFeedData.mockReturnValue([]);
+    mockGetSeriesSummaries.mockReturnValue([
+      {
+        id: 'redis',
+        title: 'Redis 완전정복',
+        latestDate: '2026-02-07',
+        firstPostSlug: 'redis-1',
+        postCount: 2,
+        totalReadingMinutes: 30,
+        posts: [
+          {
+            slug: 'redis-1',
+            title: 'Redis 1',
+            description: 'redis intro',
+            date: '2026-02-01',
+            category: 'Series',
+            series: { id: 'redis', title: 'Redis 완전정복', order: 1 },
+          },
+          {
+            slug: 'redis-2',
+            title: 'Redis 2',
+            description: 'redis advanced',
+            date: '2026-02-07',
+            category: 'Series',
+            series: { id: 'redis', title: 'Redis 완전정복', order: 2 },
+          },
+        ],
+      },
+    ]);
+
+    render(<SeriesPage />);
+
+    expect(screen.getByText('시리즈')).toBeInTheDocument();
+    expect(screen.getByText('1개 시리즈 · 2개 글')).toBeInTheDocument();
+    expect(screen.getByText('Redis 완전정복')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /첫 글부터 읽기/i })).toHaveAttribute(
+      'href',
+      '/blog/redis-1'
+    );
+  });
+
+  it('renders shared empty state when no series exists', () => {
+    mockGetSortedFeedData.mockReturnValue([]);
+    mockGetSeriesSummaries.mockReturnValue([]);
+
+    render(<SeriesPage />);
+
+    expect(screen.getByText('아직 등록된 시리즈가 없어요')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '블로그 둘러보기' })).toHaveAttribute(
+      'href',
+      '/blog'
+    );
+  });
+
+  it('does not render start CTA when first post slug is missing', () => {
+    mockGetSortedFeedData.mockReturnValue([]);
+    mockGetSeriesSummaries.mockReturnValue([
+      {
+        id: 'flink',
+        title: 'Flink 완전 정복',
+        latestDate: '2026-02-08',
+        firstPostSlug: null,
+        postCount: 1,
+        totalReadingMinutes: 12,
+        posts: [
+          {
+            slug: 'flink-1',
+            title: 'Flink 1',
+            description: 'flink intro',
+            date: '2026-02-08',
+            category: 'Series',
+            readingTime: 12,
+            series: { id: 'flink', title: 'Flink 완전 정복', order: 1 },
+          },
+        ],
+      },
+    ]);
+
+    render(<SeriesPage />);
+
+    expect(
+      screen.queryByRole('link', { name: /첫 글부터 읽기/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/blog/ui/pages/SeriesPage.tsx
+++ b/src/features/blog/ui/pages/SeriesPage.tsx
@@ -1,8 +1,9 @@
-import Link from 'next/link';
 import { Metadata } from 'next';
 import { getSortedFeedData } from '@/features/blog/services/post-repository';
 import { Header, Container } from '@/shared/layout';
-import { getSeriesGroups, formatSeriesDate } from '@/features/blog/model/series-group';
+import { EmptyState } from '@/shared/ui';
+import { getSeriesSummaries } from '@/features/blog/model/series-group';
+import { SeriesHubList } from '@/features/blog/ui/components';
 
 export const metadata: Metadata = {
   title: 'Series',
@@ -11,7 +12,11 @@ export const metadata: Metadata = {
 
 export default function SeriesPage() {
   const allPosts = getSortedFeedData();
-  const seriesGroups = getSeriesGroups(allPosts);
+  const seriesSummaries = getSeriesSummaries(allPosts);
+  const totalEpisodes = seriesSummaries.reduce(
+    (total, summary) => total + summary.postCount,
+    0
+  );
 
   return (
     <>
@@ -21,65 +26,30 @@ export default function SeriesPage() {
         <Container size="md">
           <header className="mb-12">
             <h1 className="text-3xl md:text-4xl font-bold text-[var(--color-grey-900)]">
-              Series
+              시리즈
             </h1>
             <p className="mt-4 text-lg text-[var(--color-grey-600)]">
               하나의 주제를 깊게 다룬 연재 글을 모아봤습니다
             </p>
+            <p className="mt-3 text-sm text-[var(--color-text-tertiary)]">
+              {seriesSummaries.length}개 시리즈 · {totalEpisodes}개 글
+            </p>
           </header>
 
-          {seriesGroups.length === 0 ? (
-            <div className="rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-bg-primary)] p-8 text-center text-[var(--color-text-secondary)]">
-              등록된 시리즈가 아직 없습니다.
-            </div>
+          {seriesSummaries.length === 0 ? (
+            <EmptyState
+              icon={<span className="tossface">📚</span>}
+              title="아직 등록된 시리즈가 없어요"
+              description="새로운 시리즈를 준비 중입니다. 먼저 블로그의 다른 글을 둘러보세요."
+              size="sm"
+              action={{
+                label: '블로그 둘러보기',
+                href: '/blog',
+                variant: 'secondary',
+              }}
+            />
           ) : (
-            <div className="space-y-6">
-              {seriesGroups.map((series) => (
-                <section
-                  key={series.id}
-                  className="rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-bg-primary)] p-6"
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div>
-                      <span className="inline-flex rounded-full border border-[var(--color-border)] bg-[var(--color-grey-50)] px-2 py-1 text-xs font-medium text-[var(--color-text-secondary)]">
-                        Series
-                      </span>
-                      <h2 className="mt-2 text-xl font-semibold text-[var(--color-text-primary)]">
-                        {series.title}
-                      </h2>
-                      <p className="mt-1 text-sm text-[var(--color-text-tertiary)]">
-                        총 {series.posts.length}편 · 최근 업데이트{' '}
-                        {formatSeriesDate(series.latestDate)}
-                      </p>
-                    </div>
-
-                    <Link
-                      href={`/blog/${series.posts[0]?.slug ?? ''}`}
-                      className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] px-3 py-1.5 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-hover)] hover:text-[var(--color-text-primary)]"
-                    >
-                      첫 글로 시작
-                      <span aria-hidden="true">→</span>
-                    </Link>
-                  </div>
-
-                  <ol className="mt-5 space-y-2">
-                    {series.posts.map((post) => (
-                      <li key={post.slug}>
-                        <Link
-                          href={`/blog/${post.slug}`}
-                          className="flex items-center gap-3 rounded-[var(--radius-sm)] px-3 py-2 text-sm text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-grey-50)] hover:text-[var(--color-text-primary)]"
-                        >
-                          <span className="w-6 text-[var(--color-text-tertiary)]">
-                            {post.series?.order}.
-                          </span>
-                          <span className="flex-1 truncate">{post.title}</span>
-                        </Link>
-                      </li>
-                    ))}
-                  </ol>
-                </section>
-              ))}
-            </div>
+            <SeriesHubList seriesSummaries={seriesSummaries} />
           )}
         </Container>
       </main>


### PR DESCRIPTION
## Summary
- extend series domain model with `getSeriesSummaries` aggregate fields
- replace series page list UI with reusable hub components and improved empty state
- add tracked link component for series CTA/episode analytics context
- add model/page/component tests for regression coverage

## Test
- `npx vitest run src/features/blog/model/series-group.test.ts src/features/blog/ui/components/SeriesTrackedLink.test.tsx src/features/blog/ui/pages/SeriesPage.test.tsx`
