### PR TITLE
chore(ci): PR 제목 컨벤션 강제 적용

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+## PR 제목 규칙
+- 필수 형식: `{type}({domain}): {header}`
+- 예시: `feat(blog): 모바일 TOC 접근성 개선`
+- header는 되도록 한글로 작성
+
 ## 변경 내용
 - 
 

--- a/.github/workflows/pr-title-convention.yml
+++ b/.github/workflows/pr-title-convention.yml
@@ -1,0 +1,30 @@
+name: PR Title Convention
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR title: $PR_TITLE"
+
+          pattern='^(feat|fix|refactor|docs|test|chore|perf|style|build|ci|revert)\(([a-z0-9-]+)\): .+$'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "::error title=Invalid PR title::PR 제목은 {type}({domain}): {header} 형식을 따라야 합니다. 예: feat(blog): 모바일 TOC 접근성 개선"
+            exit 1
+          fi
+
+          if [[ ! "$PR_TITLE" =~ [가-힣] ]]; then
+            echo "::notice title=Korean Header Recommended::header는 되도록 한글로 작성해주세요."
+          fi


### PR DESCRIPTION
## 변경 내용
- PR 제목 형식을 검사하는 GitHub Action 추가
- 허용 형식: `{type}({domain}): {header}`
- 형식 위반 시 체크 실패 처리
- header 한글 작성을 notice로 안내
- PR 템플릿에 제목 규칙 명시

## 검증
- 워크플로 파일 추가 및 정규식 검증 로직 확인
- PR 템플릿 가이드 반영 확인
