### PR TITLE
fix(search): 슬래시 단축키 토글 중복 수정

### DIFF
--- a/src/features/search/ui/components/CommandPalette/CommandPalette.tsx
+++ b/src/features/search/ui/components/CommandPalette/CommandPalette.tsx
@@ -23,6 +23,7 @@ export const CommandPalette = () => {
           <div className={styles.searchWrapper}>
             <KBarSearch
               className={styles.search}
+              aria-label="검색어, 태그, 글 제목 입력"
               defaultPlaceholder="검색어, 태그, 글 제목을 입력하세요"
             />
             <button

--- a/src/shared/layout/AppShell/AppShell.tsx
+++ b/src/shared/layout/AppShell/AppShell.tsx
@@ -156,32 +156,6 @@ function resolveSection(pathname: string, posts: FeedData[]): AppSection {
 function SearchButton() {
   const { query } = useKBar();
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) {
-        return;
-      }
-
-      const activeElement = document.activeElement as HTMLElement | null;
-      const tagName = activeElement?.tagName;
-      const isEditable =
-        activeElement?.isContentEditable ||
-        tagName === 'INPUT' ||
-        tagName === 'TEXTAREA' ||
-        tagName === 'SELECT';
-
-      if (isEditable) {
-        return;
-      }
-
-      event.preventDefault();
-      query.toggle();
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [query]);
-
   return (
     <button
       type="button"
@@ -212,6 +186,7 @@ function SearchButton() {
 
 export default function AppShell({ children, posts }: AppShellProps) {
   const pathname = usePathname();
+  const { query } = useKBar();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   const activeSection = useMemo(
@@ -222,6 +197,32 @@ export default function AppShell({ children, posts }: AppShellProps) {
   useEffect(() => {
     setMobileNavOpen(false);
   }, [pathname]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      const activeElement = document.activeElement as HTMLElement | null;
+      const tagName = activeElement?.tagName;
+      const isEditable =
+        activeElement?.isContentEditable ||
+        tagName === 'INPUT' ||
+        tagName === 'TEXTAREA' ||
+        tagName === 'SELECT';
+
+      if (isEditable) {
+        return;
+      }
+
+      event.preventDefault();
+      query.toggle();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [query]);
 
   return (
     <div className="min-h-screen bg-[var(--color-grey-50)] text-[var(--color-text-primary)] md:flex md:h-screen md:overflow-hidden">

--- a/tests/e2e/regression/search-shortcut.spec.ts
+++ b/tests/e2e/regression/search-shortcut.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Search shortcut', () => {
+  test('/ 단축키로 검색창이 열린 상태를 유지해요', async ({ page }) => {
+    await page.goto('/');
+
+    await page.keyboard.press('/');
+
+    const searchInput = page.getByRole('combobox', {
+      name: /검색어|태그|글 제목/,
+    });
+
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).toBeFocused();
+  });
+});


### PR DESCRIPTION
## 변경 내용
- `/` 검색 단축키 리스너를 `AppShell` 단일 위치로 이동했습니다.
- 검색 입력에 명시적 `aria-label`을 추가했습니다.
- `/` 입력 후 검색창이 열린 상태를 유지하는 Playwright 회귀 테스트를 추가했습니다.

## 의도
- 모바일/데스크톱 SearchButton이 각각 전역 keydown listener를 등록해 `/` 입력 시 검색창이 바로 닫히는 문제를 수정합니다.

## 영향 범위
- 검색 단축키 동작
- CommandPalette 검색 입력 접근성 라벨
- E2E 회귀 테스트

## 검증
- [x] `npx playwright test tests/e2e/regression/search-shortcut.spec.ts`
- [x] `npm run build`
- [ ] (필요 시) `npm test`
- [ ] 다크/라이트 모드 확인
- [ ] 모바일/데스크톱 확인

## 체크리스트
- [x] 작업 단위 브랜치(`codex/<task>`)에서 진행함
- [x] 커밋 메시지 규칙(`<type>: <한국어 설명>`) 준수
- [ ] 관련 이슈/PR 링크를 본문에 연결함