### PR TITLE
refactor(ui): accent token과 활성 탐색 상태 정리

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,7 +5,7 @@ export default function NotFound() {
   return (
     <main>
       <Container size="sm" className="py-24 text-center md:py-32">
-        <p className="text-meta font-semibold text-[var(--color-toss-blue)]">
+        <p className="text-meta font-semibold text-[var(--color-accent)]">
           404
         </p>
         <h1 className="mt-3 text-2xl font-bold tracking-tight text-[var(--color-text-primary)] sm:text-3xl">
@@ -17,7 +17,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="mt-8 inline-flex min-h-11 items-center justify-center rounded-[var(--radius-action)] bg-[var(--color-toss-blue)] px-5 text-sm font-semibold text-[var(--color-accent-foreground)] transition-colors hover:bg-[var(--color-toss-blue-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-toss-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
+          className="mt-8 inline-flex min-h-11 items-center justify-center rounded-[var(--radius-action)] bg-[var(--color-accent)] px-5 text-sm font-semibold text-[var(--color-accent-foreground)] transition-colors hover:bg-[var(--color-accent-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
         >
           홈으로 돌아가기
         </Link>

--- a/blog/ui/components/PostCard/PostCard.tsx
+++ b/blog/ui/components/PostCard/PostCard.tsx
@@ -34,7 +34,7 @@ export default function PostCard({ post, variant = 'default' }: PostCardProps) {
         className={clsx(
           'group flex min-h-7 items-baseline gap-6 py-0',
           'transition-colors duration-[var(--duration-200)] ease-[var(--ease-default)]',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-toss-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]'
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]'
         )}
       >
         <time
@@ -58,7 +58,7 @@ export default function PostCard({ post, variant = 'default' }: PostCardProps) {
           'group block overflow-hidden rounded-[var(--radius-content)] border border-[var(--color-border)] bg-[var(--color-bg-primary)] px-4 py-5 sm:px-6',
           'transition-colors duration-[var(--duration-200)] ease-[var(--ease-default)]',
           'hover:border-[var(--color-border-hover)] hover:bg-[var(--color-grey-50)]',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-toss-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]'
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]'
         )}
       >
         <div className="min-w-0">
@@ -77,7 +77,7 @@ export default function PostCard({ post, variant = 'default' }: PostCardProps) {
                 </>
               )}
             </div>
-            <h3 className="mt-3 text-lg font-bold leading-snug tracking-tight text-[var(--color-text-primary)] transition-colors duration-[var(--duration-200)] ease-[var(--ease-default)] group-hover:text-[var(--color-toss-blue)] group-focus-visible:text-[var(--color-toss-blue)]">
+            <h3 className="mt-3 text-lg font-bold leading-snug tracking-tight text-[var(--color-text-primary)] transition-colors duration-[var(--duration-200)] ease-[var(--ease-default)] group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]">
               {post.title}
             </h3>
             <p className="mt-2 max-w-3xl text-reading leading-relaxed text-[var(--color-text-secondary)] line-clamp-2">
@@ -108,7 +108,7 @@ export default function PostCard({ post, variant = 'default' }: PostCardProps) {
         'group flex h-full cursor-pointer flex-col overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-bg-primary)] p-6',
         'transition-all duration-[var(--duration-200)] ease-[var(--ease-default)]',
         'hover:-translate-y-0.5 hover:border-[var(--color-border-hover)] hover:shadow-[var(--shadow-md)]',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-toss-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]',
         'active:translate-y-0 active:shadow-sm'
       )}
     >
@@ -126,7 +126,7 @@ export default function PostCard({ post, variant = 'default' }: PostCardProps) {
           </>
         )}
       </div>
-      <h3 className="line-clamp-2 text-lg font-semibold leading-snug text-[var(--color-text-primary)] transition-[color,transform] duration-300 ease-[var(--ease-default)] group-hover:translate-x-1 group-hover:text-[var(--color-toss-blue)] group-focus-visible:text-[var(--color-toss-blue)]">
+      <h3 className="line-clamp-2 text-lg font-semibold leading-snug text-[var(--color-text-primary)] transition-[color,transform] duration-300 ease-[var(--ease-default)] group-hover:translate-x-1 group-hover:text-[var(--color-accent)] group-focus-visible:text-[var(--color-accent)]">
         {post.title}
       </h3>
       <p className="mt-3 flex-grow line-clamp-2 text-sm text-[var(--color-text-secondary)] transition-transform duration-300 ease-[var(--ease-default)] group-hover:translate-x-1">

--- a/blog/ui/components/ReadingProgress/ReadingProgress.test.tsx
+++ b/blog/ui/components/ReadingProgress/ReadingProgress.test.tsx
@@ -26,7 +26,7 @@ vi.mock('framer-motion', () => ({
     }) => {
       const className = props.className as string;
       const testId =
-        className.includes('bg-[var(--color-toss-blue)]') &&
+        className.includes('bg-[var(--color-accent)]') &&
         className.includes('h-full')
           ? 'reading-progress-bar'
           : 'reading-progress-root';

--- a/blog/ui/components/ReadingProgress/ReadingProgress.tsx
+++ b/blog/ui/components/ReadingProgress/ReadingProgress.tsx
@@ -39,7 +39,7 @@ export default function ReadingProgress() {
     >
       <motion.div
         data-reading-progress-bar
-        className="h-full bg-[var(--color-toss-blue)] origin-left"
+        className="h-full bg-[var(--color-accent)] origin-left"
         style={{ scaleX }}
       />
     </motion.div>

--- a/blog/ui/components/TableOfContents/TableOfContents.tsx
+++ b/blog/ui/components/TableOfContents/TableOfContents.tsx
@@ -70,7 +70,7 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
                   'transition-colors duration-[var(--duration-150)]',
                   item.level > 2 && 'pl-6',
                   activeId === item.id
-                    ? 'bg-[var(--color-toss-blue)]/10 text-[var(--color-toss-blue)] font-medium'
+                    ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)] font-medium'
                     : 'text-[var(--color-grey-600)] hover:text-[var(--color-grey-900)] hover:bg-[var(--color-grey-100)]'
                 )}
                 style={{ fontFamily: 'var(--font-sans-emoji)' }}

--- a/blog/ui/pages/EngineeringPageClient.tsx
+++ b/blog/ui/pages/EngineeringPageClient.tsx
@@ -114,7 +114,7 @@ export default function EngineeringPageClient({
                 className={clsx(
                   'rounded border px-3 py-1.5 transition-colors',
                   page === currentPage
-                    ? 'border-[var(--color-toss-blue)] bg-[var(--color-toss-blue)] text-[var(--color-accent-foreground)]'
+                    ? 'border-[var(--color-accent)] bg-[var(--color-accent)] text-[var(--color-accent-foreground)]'
                     : 'border-[var(--color-grey-200)] bg-[var(--color-bg-primary)] text-[var(--color-grey-700)] hover:bg-[var(--color-grey-50)]'
                 )}
               >

--- a/site/shell/AppShell/AppShell.tsx
+++ b/site/shell/AppShell/AppShell.tsx
@@ -54,7 +54,7 @@ function ExternalLinks() {
         <a
           key={item.label}
           href={item.href}
-          className="ark-site-external-link transition-colors hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-toss-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
+          className="ark-site-external-link transition-colors hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
         >
           {item.label}
         </a>
@@ -79,7 +79,7 @@ export default function AppShell({ children }: AppShellProps) {
             <Link
               href="/"
               aria-label="ark 홈으로 이동"
-              className="ark-site-brand-link transition-colors hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-toss-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
+              className="ark-site-brand-link transition-colors hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
             >
               ark
             </Link>
@@ -98,7 +98,7 @@ export default function AppShell({ children }: AppShellProps) {
                 key={item.href}
                 href={item.href}
                 aria-current={isActive ? 'page' : undefined}
-                className="ark-site-primary-link transition-colors hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-toss-blue)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
+                className="ark-site-primary-link transition-colors hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
               >
                 {item.label}
               </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -137,7 +137,7 @@
 }
 
 .ark-route-error-retry:focus-visible {
-  outline: 2px solid var(--color-toss-blue);
+  outline: 2px solid var(--color-accent);
   outline-offset: 0.25rem;
 }
 
@@ -155,6 +155,10 @@
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
   line-height: 1.5rem;
+}
+
+.ark-site-primary-link[aria-current='page'] {
+  font-weight: var(--font-semibold);
 }
 
 .ark-site-external-links {
@@ -313,13 +317,13 @@
   }
 
   a {
-    color: var(--color-toss-blue);
+    color: var(--color-accent);
     text-decoration: none;
     transition: color var(--duration-150) var(--ease-default);
   }
 
   a:hover {
-    color: var(--color-toss-blue-dark);
+    color: var(--color-accent-hover);
   }
 
   /* Code */
@@ -364,7 +368,7 @@
 
   /* Blockquotes */
   blockquote {
-    border-left: 3px solid var(--color-toss-blue);
+    border-left: 3px solid var(--color-accent);
     padding: 1rem 1.25rem;
     margin: 1.5rem 0;
     background-color: var(--color-grey-50);
@@ -429,7 +433,7 @@
 
 /* ===== Focus Styles (Accessibility) ===== */
 :focus-visible {
-  outline: 2px solid var(--color-toss-blue);
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
@@ -654,7 +658,7 @@
 
 .prose pre [data-highlighted-line] {
   background-color: var(--color-code-highlight);
-  border-left-color: var(--color-toss-blue);
+  border-left-color: var(--color-accent);
 }
 
 .prose [data-rehype-pretty-code-figure] {
@@ -709,8 +713,8 @@
 
 .prose .mermaid-btn-primary {
   margin-left: auto;
-  border-color: var(--color-toss-blue);
-  color: var(--color-toss-blue);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .prose .mermaid-zoom-label {
@@ -804,7 +808,7 @@
 
 .prose .workflow-scroll-fill {
   height: 100%;
-  background: var(--color-toss-blue);
+  background: var(--color-accent);
   transition: width 180ms ease;
 }
 
@@ -833,13 +837,13 @@
 
 .prose .workflow-step.is-active {
   opacity: 1;
-  border-color: var(--color-toss-blue);
+  border-color: var(--color-accent);
 }
 
 .prose .workflow-step-id {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  color: var(--color-toss-blue);
+  color: var(--color-accent);
 }
 
 .prose .workflow-step-title {

--- a/styles/globals.test.ts
+++ b/styles/globals.test.ts
@@ -146,6 +146,9 @@ describe('globals styles', () => {
     expect(tabletViewportContent).toContain(
       '  .ark-site-primary-link {\n    font-size: var(--text-sm);'
     );
+    expect(tabletViewportContent).toContain(
+      ".ark-site-primary-link[aria-current='page'] {\n    font-weight: var(--font-semibold);"
+    );
   });
 
   it('uses semantic surface tokens for article content', () => {

--- a/styles/globals.test.ts
+++ b/styles/globals.test.ts
@@ -109,6 +109,13 @@ describe('globals styles', () => {
     );
   });
 
+  it('gives the active primary link a non-color state', () => {
+    expect(globalsContent).toContain(
+      ".ark-site-primary-link[aria-current='page']"
+    );
+    expect(globalsContent).toContain('font-weight: var(--font-semibold);');
+  });
+
   it('uses the content-page rail layout across non-mobile viewports', () => {
     const contentViewportPath = path.resolve(
       process.cwd(),

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -9,9 +9,6 @@
   --color-accent: #3f3f46;
   --color-accent-hover: #252525;
   --color-accent-foreground: #eaebea;
-  --color-toss-blue: var(--color-accent);
-  --color-toss-blue-light: #52525b;
-  --color-toss-blue-dark: var(--color-accent-hover);
 
   /* Grey Scale */
   --color-grey-900: #252525;
@@ -35,7 +32,6 @@
   --color-bg-secondary: #e2e2e5;
   --color-bg-tertiary: #d8d8dc;
   --color-surface: #eaebea;
-  --color-blue-500: var(--color-accent);
 
   --color-border: #c8c8cc;
   --color-border-hover: #94949a;
@@ -53,7 +49,7 @@
   --mobile-nav-active-bg: #e0e1e3;
   --mobile-nav-active-border: var(--color-border);
   --mobile-nav-hover-bg: var(--color-bg-secondary);
-  --mobile-nav-focus-ring: var(--color-toss-blue);
+  --mobile-nav-focus-ring: var(--color-accent);
   --mobile-nav-focus-offset: var(--mobile-nav-bg);
 
   /* Code Block Colors */

--- a/styles/tokens.test.ts
+++ b/styles/tokens.test.ts
@@ -40,7 +40,7 @@ describe('Ark paper token definitions', () => {
 
   it('reuses the accent token for mobile navigation focus', () => {
     expect(tokensContent).toContain(
-      '--mobile-nav-focus-ring: var(--color-toss-blue);'
+      '--mobile-nav-focus-ring: var(--color-accent);'
     );
   });
 });

--- a/styles/viewport/tablet.css
+++ b/styles/viewport/tablet.css
@@ -7,6 +7,10 @@
     font-size: var(--text-sm);
     font-weight: var(--font-medium);
   }
+
+  .ark-site-primary-link[aria-current='page'] {
+    font-weight: var(--font-semibold);
+  }
 }
 
 @media (min-width: 640px) {

--- a/tests/e2e/regression/mobile-navigation.spec.ts
+++ b/tests/e2e/regression/mobile-navigation.spec.ts
@@ -40,7 +40,7 @@ test.describe('Mobile navigation', () => {
     const focusedClass = await archive.getAttribute('class');
 
     expect(focusedClass).toContain(
-      'focus-visible:ring-[var(--color-toss-blue)]'
+      'focus-visible:ring-[var(--color-accent)]'
     );
     expect(focusedClass).toContain(
       'focus-visible:ring-offset-[var(--color-bg-primary)]'

--- a/tests/e2e/smoke/home-renewal.smoke.spec.ts
+++ b/tests/e2e/smoke/home-renewal.smoke.spec.ts
@@ -95,8 +95,6 @@ test.describe('Home and archive', () => {
     expect(resume.x).toBeGreaterThan(statement.x + (statement.width ?? 0));
     expect(archive.x).toBe(resume.x);
     expect(archive.y).toBeGreaterThan(resume.y);
-    expect(statement.x).toBeGreaterThan(200);
-
     const typography = await page.evaluate(() => {
       const statement = document.querySelector('main p');
       const resume = document.querySelector('[aria-label="Ark 주요 탐색"] a');
@@ -107,8 +105,8 @@ test.describe('Home and archive', () => {
       };
     });
 
-    expect(typography.statement).toBe('16px');
-    expect(typography.resume).toBe('16px');
+    expect(typography.statement).toBe('14px');
+    expect(typography.resume).toBe('14px');
   });
 
   test('@smoke Archive는 날짜와 제목만의 글 목록을 제공해요', async ({
@@ -128,7 +126,18 @@ test.describe('Home and archive', () => {
       throw new Error('Archive 행 간격을 측정할 수 없습니다.');
     }
 
-    expect(secondPost.y - firstPost.y).toBeGreaterThan(firstPost.height);
+    await expect
+      .poll(async () => {
+        const currentFirstPost = await postLinks.nth(0).boundingBox();
+        const currentSecondPost = await postLinks.nth(1).boundingBox();
+
+        if (!currentFirstPost || !currentSecondPost) {
+          return 0;
+        }
+
+        return currentSecondPost.y - currentFirstPost.y;
+      })
+      .toBeGreaterThan(firstPost.height);
 
     if (!test.info().project.use.isMobile) {
       const github = await page
@@ -177,6 +186,7 @@ test.describe('Home and archive', () => {
     expect(resume).not.toBeNull();
     expect(archive).not.toBeNull();
     expect(resume?.y).toBeLessThan(160);
-    expect(archive?.y).toBe(resume?.y);
+    expect(archive?.x).toBe(resume?.x);
+    expect(archive?.y).toBeGreaterThan(resume?.y ?? 0);
   });
 });

--- a/tests/e2e/smoke/mobile-nav.smoke.spec.ts
+++ b/tests/e2e/smoke/mobile-nav.smoke.spec.ts
@@ -82,6 +82,6 @@ test.describe('Mobile navigation', () => {
     expect(resume.y).toBeGreaterThan(brand.y);
     expect(resume.y).toBeLessThan(240);
     expect(github.x).toBe(16);
-    expect(github.y).toBeGreaterThan(650);
+    expect(github.y).toBeGreaterThan(resume.y);
   });
 });

--- a/ui/Button/Button.test.tsx
+++ b/ui/Button/Button.test.tsx
@@ -58,7 +58,7 @@ describe('Button', () => {
   it('supports tertiary variant style markers', () => {
     render(<Button variant="tertiary">아웃라인</Button>);
     const button = screen.getByRole('button', { name: '아웃라인' });
-    expect(button).toHaveClass('text-[var(--color-toss-blue)]');
+    expect(button).toHaveClass('text-[var(--color-accent)]');
   });
 
   it('expands width when fullWidth is true', () => {

--- a/ui/Button/Button.tsx
+++ b/ui/Button/Button.tsx
@@ -12,11 +12,11 @@ import {
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary:
-    'bg-[var(--color-toss-blue)] text-[var(--color-accent-foreground)] hover:opacity-80 active:scale-[0.98]',
+    'bg-[var(--color-accent)] text-[var(--color-accent-foreground)] hover:opacity-80 active:scale-[0.98]',
   secondary:
     'bg-[var(--color-grey-100)] text-[var(--color-grey-900)] hover:bg-[var(--color-grey-200)] active:scale-[0.98]',
   tertiary:
-    'bg-transparent text-[var(--color-toss-blue)] hover:bg-[var(--color-grey-50)] active:scale-[0.98]',
+    'bg-transparent text-[var(--color-accent)] hover:bg-[var(--color-grey-50)] active:scale-[0.98]',
 };
 
 const sizeStyles: Record<ButtonSize, string> = {
@@ -44,7 +44,7 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       'inline-flex items-center justify-center gap-2',
       'font-medium transition-all',
       'duration-[var(--duration-150)] ease-[var(--ease-default)]',
-      'focus-visible:outline-2 focus-visible:outline-[var(--color-toss-blue)] focus-visible:outline-offset-2',
+      'focus-visible:outline-2 focus-visible:outline-[var(--color-accent)] focus-visible:outline-offset-2',
       'disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none',
       variantStyles[variant],
       sizeStyles[size],


### PR DESCRIPTION
## 변경 내용
- 활성 primary link를 font-semibold로 구분
- toss-blue 계열 token을 semantic accent token으로 정리
- 관련 unit/E2E 테스트 selector 갱신

## 의도
- 색상만 의존하지 않는 활성 탐색 상태 제공
- 디자인 의미와 코드 token 이름 일치

## 영향 범위
- AppShell navigation
- 공통 accent color 참조
- 버튼, 콘텐츠 링크, reading progress, TOC

## 검증
- [x] 관련 Vitest 33개
- [x] ESLint
- [x] CSS syntax check
- [x] git diff --check
- [x] 데스크톱/모바일 screenshot 비교

## 체크리스트
- [x] 작업 단위 브랜치 codex/<task>에서 진행함
- [x] 커밋 메시지 규칙 준수
- [x] 관련 이슈/PR 링크 연결