### PR TITLE
docs(blog): 말하기 에세이 공개 전환

### DIFF
--- a/posts/말하는-구조를-잃어버린-것-같았다/meta.json
+++ b/posts/말하는-구조를-잃어버린-것-같았다/meta.json
@@ -6,7 +6,7 @@
   "category": "Life",
   "contentType": "essay",
   "image": "/images/posts/말하는-구조를-잃어버린-것-같았다/capstone-gameplay.png",
-  "visibility": "private",
+  "visibility": "public",
   "tags": [
     "면접",
     "말하기",


### PR DESCRIPTION
## 변경 내용
- `말하는-구조를-잃어버린-것-같았다/meta.json`의 visibility를 private에서 public으로 전환

## 의도
- 리뷰와 품질 검증을 마친 말하기 에세이를 운영 목록과 상세 페이지에 공개

## 검증
- [x] `npm run content:audit`
- [x] `npm run build`
