### PR TITLE
fix(seo): Google 소유권 검증값 갱신

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
     follow: true,
   },
   verification: {
-    google: 'Lg-je4JjsFWeaBipKGX15JV1fsHCuM7LCmsmGCvnXiU',
+    google: 'aXrc0UTvipxLETvmauAB-p2bHGlDnCA2EWj3zjKszLQ',
     other: {
       'naver-site-verification': '94f6667c9c4ccb0b226ca6cea419f584bc0f5043',
     },


### PR DESCRIPTION
## 변경 내용
- Google Search Console HTML 태그 소유권 검증값을 갱신했습니다.

## 의도
- `https://ark-log.vercel.app/` URL 접두어 속성을 검증하고 sitemap 제출을 가능하게 합니다.

## 영향 범위
- 전역 HTML metadata의 Google 검증 메타 태그만 변경됩니다.

## 검증
- [x] `npm run build`

## 체크리스트
- [x] 작업 단위 브랜치(`codex/seo-google-verification`)에서 진행함
- [x] 커밋 메시지 규칙 준수