### PR TITLE
fix(shell): 헤더 로고 mark 제거

### DIFF
--- a/site/shell/AppShell/AppShell.test.tsx
+++ b/site/shell/AppShell/AppShell.test.tsx
@@ -39,7 +39,7 @@ describe('AppShell', () => {
     ).toBeInTheDocument();
   });
 
-  it('treats existing post routes as part of Archive', () => {
+  it('treats existing post routes as part of Archive without a header mark', () => {
     vi.mocked(usePathname).mockReturnValue('/blog/ctr-pipeline');
     render(
       <AppShell>
@@ -51,9 +51,6 @@ describe('AppShell', () => {
       'aria-current',
       'page'
     );
-    expect(screen.getByAltText('')).toHaveAttribute(
-      'src',
-      '/brand/graphite-blossom-mark.svg'
-    );
+    expect(screen.queryByAltText('')).not.toBeInTheDocument();
   });
 });

--- a/site/shell/AppShell/AppShell.tsx
+++ b/site/shell/AppShell/AppShell.tsx
@@ -81,14 +81,6 @@ export default function AppShell({ children }: AppShellProps) {
               aria-label="ark 홈으로 이동"
               className="ark-site-brand-link transition-colors hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-primary)]"
             >
-              {pathname !== '/' ? (
-                <img
-                  src="/brand/graphite-blossom-mark.svg"
-                  alt=""
-                  aria-hidden="true"
-                  className="ark-site-brand-mark"
-                />
-              ) : null}
               <span>ark</span>
             </Link>
           </header>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -55,12 +55,6 @@
   pointer-events: auto;
 }
 
-.ark-site-brand-mark {
-  width: 1.75rem;
-  height: 1.75rem;
-  flex: none;
-}
-
 .ark-site-content {
   grid-column: 2;
   grid-row: 1;


### PR DESCRIPTION
## 변경 사항
- 헤더 왼쪽 `ark` 텍스트 앞의 blossom mark 이미지를 제거합니다.
- 파비콘은 그대로 유지합니다.
- 사용하지 않는 mark 스타일과 렌더링 테스트를 정리합니다.

## 검증
- `npm run test:components -- site/shell/AppShell/AppShell.test.tsx`
- `npm run build`
- `git diff --check`