### PR TITLE
fix(blog): 띠부씰 이미지 크기 축소

### DIFF
--- a/posts/chakchak-build-retrospective/index.mdx
+++ b/posts/chakchak-build-retrospective/index.mdx
@@ -55,12 +55,14 @@
 
 며칠 뒤 같은 빵에서 30주년 한정판 파이리까지 나왔다. 이건 운명이다 싶었다.
 
-<ImageGrid cols={2} gap={24}>
-  ![처음 나온 2026 NEW 시즌5 30주년 에몽가
-  띠부씰](/images/posts/chakchak-build-retrospective/season5-30th-emolga.webp)
-  ![며칠 뒤 나온 2026 NEW 시즌5 30주년 파이리
-  띠부씰](/images/posts/chakchak-build-retrospective/season5-30th-charmander.webp)
-</ImageGrid>
+<div className="mx-auto max-w-lg">
+  <ImageGrid cols={2} gap={24}>
+    ![처음 나온 2026 NEW 시즌5 30주년 에몽가
+    띠부씰](/images/posts/chakchak-build-retrospective/season5-30th-emolga.webp)
+    ![며칠 뒤 나온 2026 NEW 시즌5 30주년 파이리
+    띠부씰](/images/posts/chakchak-build-retrospective/season5-30th-charmander.webp)
+  </ImageGrid>
+</div>
 
 포켓몬이 완전히 낯선 것은 아니었다. 포켓몬스터 골드를 해봤고
 디아루가, 펄기아, 아르세우스까지의 큰 스토리도 알고 있었다. 다만 최근의


### PR DESCRIPTION
## 변경 내용
- 30주년 에몽가·파이리 이미지 그리드의 최대 너비를 `max-w-lg`로 제한
- 이미지 묶음을 본문 가운데에 정렬

## 의도
- 저해상도 원본이 데스크톱에서 과도하게 확대되어 흐릿하게 보이는 문제를 줄입니다.
- 해당 이미지 묶음만 조정해 다른 게시물 이미지와 그리드에는 영향을 주지 않습니다.

## 영향 범위
- `posts/chakchak-build-retrospective/index.mdx`

## 검증
- [x] `npm run build`
- [ ] (필요 시) `npm test`
- [ ] 다크/라이트 모드 확인
- [ ] 모바일/데스크톱 확인

## 체크리스트
- [x] 작업 단위 브랜치(`codex/<task>`)에서 진행함
- [x] 커밋 메시지 규칙 준수
- [x] 관련 이슈/PR 링크가 필요하지 않은 독립 콘텐츠 수정