### PR TITLE
fix(blog): 띠부씰 이미지 크기 추가 축소

### DIFF
--- a/posts/chakchak-build-retrospective/index.mdx
+++ b/posts/chakchak-build-retrospective/index.mdx
@@ -55,7 +55,7 @@
 
 며칠 뒤 같은 빵에서 30주년 한정판 파이리까지 나왔다. 이건 운명이다 싶었다.
 
-<div className="mx-auto max-w-lg">
+<div className="mx-auto max-w-64">
   <ImageGrid cols={2} gap={24}>
     ![처음 나온 2026 NEW 시즌5 30주년 에몽가
     띠부씰](/images/posts/chakchak-build-retrospective/season5-30th-emolga.webp)


### PR DESCRIPTION
## 변경 내용
- 에몽가·파이리 이미지 묶음의 최대 너비를 `512px`에서 `256px`로 축소
- 카드 한 장의 표시 폭을 약 `244px`에서 `116px`로 조정

## 의도
- 저해상도 띠부씰 이미지가 본문에서 여전히 크게 보이는 문제를 줄입니다.
- 표시 면적을 이전의 약 1/4로 축소해 이야기 흐름을 방해하지 않도록 합니다.

## 영향 범위
- `posts/chakchak-build-retrospective/index.mdx` 한 줄

## 검증
- [x] `npm run build`
- [ ] (필요 시) `npm test`
- [ ] 다크/라이트 모드 확인
- [ ] 모바일/데스크톱 확인

## 체크리스트
- [x] 작업 단위 브랜치(`codex/<task>`)에서 진행함
- [x] 커밋 메시지 규칙 준수
- [x] 관련 이슈/PR 링크가 필요하지 않은 독립 콘텐츠 수정